### PR TITLE
Stop enforcing specific python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,3 @@ repos:
     rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3.11


### PR DESCRIPTION
Let's drop the python 3.11 requirement if there is no specific reason for having this requirement.