### PR TITLE
Fix compilation error in SLPVectorizer

### DIFF
--- a/lib/Transforms/SLPVectorizer.cpp
+++ b/lib/Transforms/SLPVectorizer.cpp
@@ -1301,7 +1301,7 @@ void WaterGreedySLPVectorizerPass::runOnOperation() {
 
     auto sizeInBits = dataLayout->getTypeSizeInBits(type);
 
-    return sizeInBits * count <= this->maxVectorBitwidth;
+    return sizeInBits.getFixedValue() * count <= this->maxVectorBitwidth;
   };
 
   // Run until fixed point is reached.


### PR DESCRIPTION
Fixed ambiguous operator overload error when multiplying `llvm::TypeSize` with `size_t` by calling `getFixedValue()` on the TypeSize returned by `getTypeSizeInBits()`.