### PR TITLE
Dataflow analysis for shape inference 

### DIFF
--- a/include/water/Dialect/Wave/IR/CMakeLists.txt
+++ b/include/water/Dialect/Wave/IR/CMakeLists.txt
@@ -14,6 +14,13 @@ mlir_tablegen(WaveDialect.cpp.inc -gen-dialect-defs -dialect=wave)
 add_public_tablegen_target(MLIRWaveDialectIncGen)
 add_dependencies(MLIRWaveIncGen MLIRWaveTypesIncGen)
 
+set(LLVM_TARGET_DEFINITIONS WaveInterfaces.td)
+mlir_tablegen(WaveOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(WaveOpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(MLIRWaveInterfacesIncGen)
+add_dependencies(MLIRWaveIncGen MLIRWaveInterfacesIncGen)
+add_mlir_doc(WaveInterfaces WaveOpInterfaces Dialects/ -gen-op-interface-docs)
+
 set(LLVM_TARGET_DEFINITIONS WaveOps.td)
 mlir_tablegen(WaveOps.h.inc -gen-op-decls)
 mlir_tablegen(WaveOps.cpp.inc -gen-op-defs)

--- a/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -7,8 +7,13 @@
 #ifndef WATER_DIALECT_WAVE_IR_WAVEINTERFACES_H
 #define WATER_DIALECT_WAVE_IR_WAVEINTERFACES_H
 
+#include "water/Dialect/Wave/IR/WaveTypes.h"
+
+#include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace wave {
 
@@ -29,6 +34,85 @@ mlir::ParseResult parseWaveIndexDict(mlir::OpAsmParser &parser,
                                      mlir::DictionaryAttr &out);
 void printWaveIndexDict(mlir::OpAsmPrinter &printer, mlir::Operation *op,
                         mlir::DictionaryAttr dict);
+
+namespace detail {
+// Propagate shape information from `from` tensor types to `to` tensor types.
+// Expects all fully-specified tensor types to have the same shape, prints an
+// error message to `errs` otherwise. Update all under-specified tensor types in
+// `to` to be fully specified with the shapes extracted from from. For
+// fully-specified types in `to`, check if their shapes match those in `from`
+// and print error messages to `errs` otherwise. The error message uses `toName`
+// and `fromName` to to describe `from` and `to` tensors. If there was an error
+// due to mismatching/irreconcilable types and an error was printed, returns
+// `failure`. Otherwise returns an change indicator.
+llvm::FailureOr<mlir::ChangeResult>
+identityTypeInferencePropagate(llvm::ArrayRef<wave::WaveTensorType> from,
+                               llvm::MutableArrayRef<wave::WaveTensorType> to,
+                               llvm::StringRef fromName, llvm::StringRef toName,
+                               llvm::raw_ostream &errs);
+llvm::FailureOr<mlir::ChangeResult>
+propagateShapeInformation(wave::WaveTensorType from, wave::WaveTensorType &to,
+                          llvm::StringRef fromName, llvm::StringRef toName,
+                          llvm::raw_ostream &errs);
+
+// Check whether the `from` and `to` tensor types have reconcilable shapes and
+// and print error messages to `errs` otherwise. The error message uses `toName`
+// and `fromName` to to describe `from` and `to` tensors. If types are
+// reconcilable, returns an indicator whether the `to` type will have to be
+// updated.
+llvm::FailureOr<mlir::ChangeResult>
+checkPropagateShapeConflict(wave::WaveTensorType from, wave::WaveTensorType to,
+                            llvm::StringRef fromName, llvm::StringRef toName,
+                            llvm::raw_ostream &errs);
+
+} // namespace detail
+
+// A trait providing an implementation of the WaveInferTypeOpInterface where
+// shapes are propagated from all operands to all results and back as is.
+template <typename OpTy>
+class IdentityTypeInferenceOpTrait
+    : public mlir::OpTrait::TraitBase<OpTy, IdentityTypeInferenceOpTrait> {
+public:
+  llvm::FailureOr<mlir::ChangeResult>
+  propagateForward(llvm::ArrayRef<wave::WaveTensorType> operandTypes,
+                   llvm::MutableArrayRef<wave::WaveTensorType> resultTypes,
+                   llvm::raw_ostream &errs) {
+    return wave::detail::identityTypeInferencePropagate(
+        operandTypes, resultTypes, "operands", "results", errs);
+  }
+
+  llvm::FailureOr<mlir::ChangeResult>
+  propagateBackward(llvm::MutableArrayRef<wave::WaveTensorType> operandTypes,
+                    llvm::ArrayRef<wave::WaveTensorType> resultTypes,
+                    llvm::raw_ostream &errs) {
+    return wave::detail::identityTypeInferencePropagate(
+        resultTypes, operandTypes, "results", "operands", errs);
+  }
+};
+
+// A trait providing an implementation of the WaveInferTypeOpInterface where no
+// shape propagation is needed. E.g. for operations that only have operands and
+// no results.
+template <typename OpTy>
+class NoOpTypeInferenceOpTrait
+    : public mlir::OpTrait::TraitBase<OpTy, NoOpTypeInferenceOpTrait> {
+public:
+  llvm::FailureOr<mlir::ChangeResult>
+  propagateForward(llvm::ArrayRef<wave::WaveTensorType> operandTypes,
+                   llvm::MutableArrayRef<wave::WaveTensorType> resultTypes,
+                   llvm::raw_ostream &errs) {
+    return mlir::ChangeResult::NoChange;
+  }
+
+  llvm::FailureOr<mlir::ChangeResult>
+  propagateBackward(llvm::MutableArrayRef<wave::WaveTensorType> operandTypes,
+                    llvm::ArrayRef<wave::WaveTensorType> resultTypes,
+                    llvm::raw_ostream &errs) {
+    return mlir::ChangeResult::NoChange;
+  }
+};
 } // namespace wave
+
+#include "water/Dialect/Wave/IR/WaveOpInterfaces.h.inc"
 
 #endif // WATER_DIALECT_WAVE_IR_WAVEINTERFACES_H

--- a/include/water/Dialect/Wave/IR/WaveInterfaces.td
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.td
@@ -10,6 +10,52 @@
 include "mlir/IR/OpBase.td"
 
 def HasWaveIndexMapping : NativeOpTrait<"HasWaveIndexMapping"> {
+    let cppNamespace = "::wave";
+}
+
+def WaveInferTypeOpInterface : OpInterface<"WaveInferTypeOpInterface"> {
+  let description = [{
+    Interface capturing op-specific type inference rules inside the Wave
+    dialect. Type inference proceeds forward and backward on a function in order
+    to fully resolve shapes. Each operation may indicate how to update the types
+    of its results based on the types of its operands and, conversely, the types
+    of its operands based on the types of its results.
+  }];
+  let cppNamespace = "::wave";
+
+  let methods = [
+    InterfaceMethod<[{
+      Propagate type information from operands to results. Result types may be
+      updated in place. If propagation would lead to a type conflict, return
+      failure and print additional information into the provided error stream.
+      Otherwise return an indication whether result types were updated.
+      }],
+      "::llvm::FailureOr<::mlir::ChangeResult>", "propagateForward",
+      (ins "::llvm::ArrayRef<::wave::WaveTensorType>":$operandTypes,
+           "::llvm::MutableArrayRef<::wave::WaveTensorType>":$resultTypes,
+           "::llvm::raw_ostream &":$errs)
+    >,
+    InterfaceMethod<[{
+      Propagate type information from results to operands. Operand types may be
+      updated in place. If propagation would lead to a type conflict, return
+      failure and print additional information into the provided error stream.
+      Otherwise return an indication whether operand types were updated.
+      }],
+      "::llvm::FailureOr<::mlir::ChangeResult>",
+      "propagateBackward",
+      (ins "::llvm::MutableArrayRef<::wave::WaveTensorType>":$operandTypes,
+           "::llvm::ArrayRef<::wave::WaveTensorType>":$resultTypes,
+           "::llvm::raw_ostream &":$errs)
+    >
+  ];
+}
+
+def IdentityTypeInferenceOpTrait
+    : NativeOpTrait<"IdentityTypeInferenceOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
+def NoOpTypeInferenceOpTrait : NativeOpTrait<"NoOpTypeInferenceOpTrait"> {
   let cppNamespace = "::wave";
 }
 

--- a/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/include/water/Dialect/Wave/IR/WaveOps.td
@@ -46,7 +46,8 @@ class WaveArithmeticOpDoc {
 }
 
 class UnaryWaveOp<string mnemonic>
-    : WaveOp<mnemonic>,
+    : WaveOp<mnemonic,
+         [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait]>,
       WaveArithmeticOpDoc {
   let arguments = !con((ins
     Arg<WaveTensorInRegister, "Argument">:$argument
@@ -61,7 +62,8 @@ class UnaryWaveOp<string mnemonic>
 }
 
 class BinaryWaveOp<string mnemonic>
-    : WaveOp<mnemonic>,
+    : WaveOp<mnemonic,
+         [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait]>,
       WaveArithmeticOpDoc {
   let arguments = !con((ins
     Arg<WaveTensorInRegister, "Left-hand side">:$lhs,
@@ -101,9 +103,9 @@ def Exp2Op : UnaryWaveOp<"exp2"> {
   let description = baseDescription;
 }
 
-def MmaOp
-    : WaveOp<"mma">,
-      WaveArithmeticOpDoc {
+def MmaOp : WaveOp<"mma",
+    [DeclareOpInterfaceMethods<WaveInferTypeOpInterface>]>,
+            WaveArithmeticOpDoc {
   let summary = "Matrix multiply and accumulate";
   let description = baseDescription # [{
     The mandatory `kind` attribute indicates which configuration to use in
@@ -185,7 +187,8 @@ def YieldOp : Op<WaveDialect, "yield",
 // Memory-related operations
 //-----------------------------------------------------------------------------
 
-def ReadOp : WaveOp<"read"> {
+def ReadOp : WaveOp<"read", [
+    WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait]> {
   let summary = "Reads from memory";
   let description = [{
     Moves data from a memory-resident tensor to a register-resident tensor
@@ -204,7 +207,8 @@ def ReadOp : WaveOp<"read"> {
                        "functional-type(operands, results)";
 }
 
-def RegisterOp : WaveOp<"register"> {
+def RegisterOp : WaveOp<"register", [
+    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait]> {
   let summary = "Defines a tensor value known to be placed in a register";
   let description = [{
     Defines a new register-resident tensor initialized with the given scalar
@@ -227,7 +231,8 @@ def RegisterOp : WaveOp<"register"> {
   let hasVerifier = 1;
 }
 
-def WriteOp : WaveOp<"write"> {
+def WriteOp : WaveOp<"write", [
+    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait]> {
   let summary = "Writes into memory";
   let description = [{
     Moves data from a register-resident tensor into a memory-resident tensor

--- a/include/water/Dialect/Wave/IR/WaveTypes.td
+++ b/include/water/Dialect/Wave/IR/WaveTypes.td
@@ -79,6 +79,18 @@ def WaveTensorType : TypeDef<WaveDialect, "WaveTensor"> {
     ::wave::WaveAddressSpace getAddressSpaceValue() const {
       return getAddressSpace().getValue();
     }
+
+    // Return a tensor with the same element type and address space and the
+    // shape copied from the other tensor.
+    ::wave::WaveTensorType copyShapeFrom(::wave::WaveTensorType other) {
+      if (other.getElementType() == getElementType() &&
+          other.getAddressSpace() == getAddressSpace())
+        return other;
+
+      return ::wave::WaveTensorType::get(
+          getContext(), other.getShape(), other.getFullySpecified(),
+          getElementType(), getAddressSpace());
+    }
   }];
 }
 

--- a/include/water/Dialect/Wave/Transforms/CMakeLists.txt
+++ b/include/water/Dialect/Wave/Transforms/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc --gen-pass-decls)
-add_public_tablegen_target(MLIRLowerWavePassesIncGen)
+add_public_tablegen_target(MLIRWaterWavePassesIncGen)

--- a/include/water/Dialect/Wave/Transforms/Passes.td
+++ b/include/water/Dialect/Wave/Transforms/Passes.td
@@ -21,4 +21,27 @@ def LowerWaveToMLIRPass : Pass<"lower-wave-to-mlir"> {
   ];
 }
 
+def WaterWaveInferTypesPass : Pass<"water-wave-infer-types"> {
+  let summary = "Infer fully-specified Wave dialect types";
+  let description = [{
+    Performs forward and backward sparse dataflow analysis propagating shape
+    information for Wave tensor types. All operations using these types are
+    expected to implement WaveInferTypeOpInterface to indicate rules for shape
+    propagation across them. Traits provide implementations for common cases.
+
+    Reports errors if a type conflict is detected, for example, if a value with
+    `any` shape would need two different concrete shapes based on propagation
+    from different control flow paths or from different directions.
+  }];
+
+  let options = [
+    Option</*varName=*/"force",
+           /*arg=*/"force",
+           /*valueType=*/"bool",
+           /*default=*/"false",
+           "Keep processing after error emission without updating the type. "
+           "May construct invalid IR useful for debugging">
+  ];
+}
+
 #endif // WATER_DIALECT_WAVE_TRANSFORMS_PASSES

--- a/lib/Dialect/Wave/IR/CMakeLists.txt
+++ b/lib/Dialect/Wave/IR/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(MLIRWaveDialect
   WaveInterfaces.cpp
   WaveAttrs.cpp
   WaveDialect.cpp
+  WaveInterfaces.cpp
   WaveOps.cpp
   WaveTypes.cpp
 

--- a/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -9,6 +9,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
+#include "water/Dialect/Wave/IR/WaveTypes.h"
 
 using namespace mlir;
 
@@ -106,3 +107,74 @@ void wave::printWaveIndexDict(OpAsmPrinter &printer, Operation *op,
       });
   printer.getStream() << "}";
 }
+
+// Return `true` if two tensor types have the same shape. Null types are
+// considered to have different shapes.
+static bool hasSameShape(wave::WaveTensorType lhs, wave::WaveTensorType rhs) {
+  // TODO: this may require more advanced checking if shapes are more complex
+  // than a single symbol.
+  return lhs && rhs && lhs.getShape() == rhs.getShape();
+}
+
+llvm::FailureOr<mlir::ChangeResult> wave::detail::checkPropagateShapeConflict(
+    wave::WaveTensorType from, wave::WaveTensorType to,
+    llvm::StringRef fromName, llvm::StringRef toName, llvm::raw_ostream &errs) {
+  if (!from || !to || hasSameShape(from, to))
+    return mlir::ChangeResult::NoChange;
+
+  if (!to.getFullySpecified())
+    return mlir::ChangeResult::Change;
+
+  errs << "irreconcilable types during type inference from " << fromName << "("
+       << from << ") to " << toName << "(" << to << ")";
+  return mlir::failure();
+}
+
+llvm::FailureOr<mlir::ChangeResult> wave::detail::propagateShapeInformation(
+    wave::WaveTensorType from, wave::WaveTensorType &to,
+    llvm::StringRef fromName, llvm::StringRef toName, llvm::raw_ostream &errs) {
+  llvm::FailureOr<mlir::ChangeResult> res =
+      checkPropagateShapeConflict(from, to, fromName, toName, errs);
+  if (mlir::failed(res) || *res == mlir::ChangeResult::NoChange)
+    return res;
+
+  to = to.copyShapeFrom(from);
+  return mlir::ChangeResult::Change;
+}
+
+llvm::FailureOr<mlir::ChangeResult>
+wave::detail::identityTypeInferencePropagate(
+    llvm::ArrayRef<wave::WaveTensorType> from,
+    llvm::MutableArrayRef<wave::WaveTensorType> to, llvm::StringRef fromName,
+    llvm::StringRef toName, llvm::raw_ostream &errs) {
+  auto it = llvm::find_if(from, [](wave::WaveTensorType type) {
+    return type && type.getFullySpecified();
+  });
+  if (it == from.end())
+    return mlir::ChangeResult::NoChange;
+
+  // Expect all fully-specified "from" types to have the same shape.
+  for (auto [i, fr] : llvm::enumerate(from)) {
+    llvm::FailureOr<mlir::ChangeResult> res =
+        checkPropagateShapeConflict(*it, fr, fromName, toName, errs);
+    if (mlir::failed(res)) {
+      errs << " for " << fromName << " #" << i;
+      return res;
+    }
+  }
+
+  mlir::ChangeResult changeResult = mlir::ChangeResult::NoChange;
+  for (auto &&[i, toType] : llvm::enumerate(to)) {
+    llvm::FailureOr<mlir::ChangeResult> res =
+        propagateShapeInformation(*it, toType, fromName, toName, errs);
+    if (mlir::failed(res)) {
+      errs << " for " << fromName << " #" << i;
+      return mlir::failure();
+    }
+
+    changeResult |= *res;
+  }
+  return changeResult;
+}
+
+#include "water/Dialect/Wave/IR/WaveOpInterfaces.cpp.inc"

--- a/lib/Dialect/Wave/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Wave/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_mlir_dialect_library(MLIRLowerWaveTransforms
+add_mlir_dialect_library(MLIRWaveTransforms
+  InferTypes.cpp
   LowerRegister.cpp
   LowerWaveToMLIR.cpp
   TypeConverter.cpp
@@ -7,7 +8,7 @@ add_mlir_dialect_library(MLIRLowerWaveTransforms
   ${PROJECT_SOURCE_DIR}/include/water/
 
   DEPENDS
-  MLIRLowerWavePassesIncGen
+  MLIRWaterWavePassesIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -1,0 +1,517 @@
+// Copyright 2025 The Water Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveOps.h"
+#include "water/Dialect/Wave/Transforms/Passes.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#define DEBUG_TYPE "wave-infer-types"
+
+namespace wave {
+#define GEN_PASS_DEF_WATERWAVEINFERTYPESPASS
+#include "water/Dialect/Wave/Transforms/Passes.h.inc"
+} // namespace wave
+
+namespace {
+
+// Core lattice for type/shape inference of wave tensors. In addition to the
+// bottom and top states, it can represent have a concrete type which bay be
+// a fully specified tensor type (specific) or an underspecified type (any). The
+// JOIN function is defined by the following table:
+//
+// JOIN         top       specific       any         bottom
+// top          top       top            top         top
+// specific     top       specific|top*  specific    specific
+// any          top       specific       any         any
+// bottom       top       specific       any         bottom
+//   * if two specific shapes are equal, their JOIN is equal to them, otherwise
+//     it is an inference conflict and the result of a JOIN is the top state.
+//
+// The explicit bottom type is mostly there for debugging purposes: lattice
+// instances are default-constructed in this state and them remaining in it
+// after the analysis converges means the analysis hasn't updated or may not
+// have explicitly initialized the state.
+class InferTypeLatticeStorage {
+public:
+  InferTypeLatticeStorage() : value(nullptr, kUninitializedState) {}
+  InferTypeLatticeStorage(const InferTypeLatticeStorage &value) = default;
+  InferTypeLatticeStorage(wave::WaveTensorType concreteValue)
+      : value(concreteValue, kSpecificTypeState) {}
+
+  InferTypeLatticeStorage &
+  operator=(const InferTypeLatticeStorage &other) = default;
+
+  bool operator==(const InferTypeLatticeStorage &other) const {
+    return value == other.value;
+  }
+
+  // Return true if this lattice instance is the bottom state.
+  bool isBottom() const { return value.getInt() == kUninitializedState; }
+
+  // Return true if this lattice instance is the top state.
+  bool isTop() const { return value.getInt() == kUndecidableState; }
+
+  // Returns the concrete type stored in the lattice instance, be it fully
+  // specified or not, or null if the lattice instance is a top or a bottom.
+  wave::WaveTensorType getConcreteValue() const {
+    if (value.getInt() != kSpecificTypeState)
+      return nullptr;
+    return llvm::cast<wave::WaveTensorType>(value.getPointer());
+  }
+
+  // Return the top lattice instance.
+  static InferTypeLatticeStorage top() {
+    InferTypeLatticeStorage result;
+    result.value.setPointer(nullptr);
+    result.value.setInt(kUndecidableState);
+    return result;
+  }
+
+  // Join the two lattice instances and return the result.
+  static InferTypeLatticeStorage join(const InferTypeLatticeStorage &lhs,
+                                      const InferTypeLatticeStorage &rhs) {
+    if (lhs.value == rhs.value)
+      return lhs;
+
+    if (lhs.isTop() || rhs.isTop())
+      return top();
+
+    if (lhs.isBottom())
+      return rhs;
+
+    if (rhs.isBottom())
+      return lhs;
+
+    // If one of the types is under-specified, return the other type.
+    wave::WaveTensorType lhsType = lhs.getConcreteValue();
+    wave::WaveTensorType rhsType = rhs.getConcreteValue();
+    if (!lhsType.getFullySpecified())
+      return rhs;
+    if (!rhsType.getFullySpecified())
+      return lhs;
+
+    // We only care about shape matches.
+    if (lhsType.getShape() == rhsType.getShape())
+      return lhsType;
+
+    return top();
+  }
+
+  // XXX: backward analysis calls `meet` instead of `join`, but it isn't related
+  // to the direction of the analysis. Just defer to join.
+  static InferTypeLatticeStorage meet(const InferTypeLatticeStorage &lhs,
+                                      const InferTypeLatticeStorage &rhs) {
+    return join(lhs, rhs);
+  }
+
+  // Forcibly assign the current value of the lattice. This MUST NOT be used in
+  // the transfer functions as it may be moving the instance back on the lattice
+  // and therefore breaking the analysis convergence guarantees due to
+  // non-monotonicity. This is useful during forceful initialization to override
+  // the quirk of the dataflow framework using the same function
+  // (`setToEntry/ExitState`) to both initialize the analysis and to indicate
+  // failure to analyze. Those functions can keep setting the lattice to the top
+  // state.
+  void unsafeSet(const InferTypeLatticeStorage &value) {
+    this->value = value.value;
+  }
+
+  void print(llvm::raw_ostream &os) const {
+    if (isBottom())
+      os << "<bottom>";
+    else if (isTop())
+      os << "<top>";
+    else
+      os << getConcreteValue();
+  }
+
+  LLVM_DUMP_METHOD void dump() const { print(llvm::errs()); }
+
+private:
+  // The internal storage is either a type or one of the top/bottom flags.
+  llvm::PointerIntPair<mlir::Type, 2> value;
+
+  // State flags.
+  const static unsigned kUninitializedState = 0;
+  const static unsigned kSpecificTypeState = 1;
+  const static unsigned kUndecidableState = 2;
+};
+
+// Typed lattice object for type inference.
+class InferTypeLattice
+    : public mlir::dataflow::Lattice<InferTypeLatticeStorage> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InferTypeLattice);
+  using Lattice::Lattice;
+};
+
+// Helper function for forward/backward inference handling ops that do not
+// implement the inference interface. Returns success if the op doesn't
+// manipulate wave tensor types, failure otherwise. Returns nullopt if the op
+// does implement the interface.
+static std::optional<llvm::LogicalResult>
+handleNonInterfaceOp(mlir::Operation *op) {
+  if (llvm::isa<wave::WaveInferTypeOpInterface>(op))
+    return std::nullopt;
+
+  if (!llvm::any_of(op->getOperandTypes(),
+                    llvm::IsaPred<wave::WaveTensorType>) &&
+      !llvm::any_of(op->getResultTypes(),
+                    llvm::IsaPred<wave::WaveTensorType>)) {
+    return mlir::success();
+  }
+  return op->emitError()
+         << "cannot propagate types across an operation not implementing "
+            "the wave infer type interface";
+}
+
+// Dataflow analysis propagating type/shape information from operands to
+// results. This is an optimistic sparse context-insensitive forward dataflow
+// analysis intended for intra-procedural use and composition with the
+// equivalent backward analysis. It starts by initializing a lattice instance
+// for all wave tensor-typed operation results and block arguments to their
+// current type and propagates shape information across operations using
+// WaveInferTypeOpInterface as well as across control flow using regular control
+// flow interfaces until convergence. In case of a type inference conflict, e.g.
+// the pre-existing type is different from the type inferred by dataflow, a
+// diagnostic is emitted and the lattice instance corresponding to the value
+// with type conflict is set to the top state. If the analysis fails due to the
+// lack of information, e.g., control flow operations not implementing the
+// requested interfaces, the lattice instances may be set to the top state
+// without diagnostics.
+class InferTypeForwardAnalysis
+    : public mlir::dataflow::SparseForwardDataFlowAnalysis<InferTypeLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  // Forcibly initializes lattice instances for wave tensor-typed operation
+  // results and block arguments of supported operations to their current type.
+  //
+  // XXX: this works since we never revisit the function entry block again in
+  // the intra-procedural case. Without this function, the framework would call
+  // `setToEntryState` that would trigger setting to lattice top which we don't
+  // want.
+  mlir::LogicalResult initialize(mlir::Operation *top) override {
+    if (getSolverConfig().isInterprocedural())
+      return top->emitError() << "interprocedural analysis not supported";
+
+    // Call the base class initialization in order to set up update listeners.
+    // Note that this will initialize values at function/region entries to
+    // lattice top.
+    if (mlir::failed(AbstractSparseForwardDataFlowAnalysis::initialize(top)))
+      return mlir::failure();
+
+    // Reset the initialization of values that may have been initialized to
+    // lattice top to the concrete type instead.
+    top->walk([&](mlir::Operation *op) {
+      if (auto iface = llvm::dyn_cast<wave::WaveInferTypeOpInterface>(op)) {
+        initForResults(iface);
+      } else if (auto iface = llvm::dyn_cast<mlir::FunctionOpInterface>(op)) {
+        if (!iface.isDeclaration())
+          initForBlockArguments(iface.getFunctionBody().front());
+      } else if (auto iterate = llvm::dyn_cast<wave::IterateOp>(op)) {
+        initForResults(op);
+        initForBlockArguments(iterate.getBody().front());
+      }
+      return mlir::WalkResult::advance();
+    });
+    return mlir::success();
+  }
+
+  // Called by base class initialization and when the analysis fails to identify
+  // lattices to join.
+  void setToEntryState(InferTypeLattice *lattice) override {
+    propagateIfChanged(lattice, lattice->join(InferTypeLatticeStorage::top()));
+  }
+
+  // Dataflow transfer function, defers to the WaveInferTypeOpInterface.
+  mlir::LogicalResult
+  visitOperation(mlir::Operation *op,
+                 llvm::ArrayRef<const InferTypeLattice *> operands,
+                 llvm::ArrayRef<InferTypeLattice *> results) override {
+    std::optional<mlir::LogicalResult> res = handleNonInterfaceOp(op);
+    if (res)
+      return *res;
+
+    auto extractType = [](const InferTypeLattice *lattice) {
+      return lattice->getValue().getConcreteValue();
+    };
+    llvm::SmallVector<wave::WaveTensorType> operandTypes =
+        llvm::map_to_vector(operands, extractType);
+    llvm::SmallVector<wave::WaveTensorType> resultTypes =
+        llvm::map_to_vector(results, extractType);
+
+    std::string errorMessage;
+    llvm::raw_string_ostream errs(errorMessage);
+    llvm::FailureOr<mlir::ChangeResult> result =
+        llvm::cast<wave::WaveInferTypeOpInterface>(op).propagateForward(
+            operandTypes, resultTypes, errs);
+    if (mlir::failed(result)) {
+      return op->emitError()
+             << "failed to propagate type information forward: " << errs.str();
+    }
+    if (*result == mlir::ChangeResult::NoChange)
+      return mlir::success();
+
+    for (auto &&[result, lattice] : llvm::zip_equal(resultTypes, results)) {
+      propagateIfChanged(lattice,
+                         lattice->join(InferTypeLatticeStorage(result)));
+    }
+    return mlir::success();
+  }
+
+private:
+  // Initialize the lattice instance for the given value to its current type and
+  // trigger dataflow propagation. Returns the lattice instance or null if the
+  // value is not of wave tensor type.
+  InferTypeLattice *initForValue(mlir::Value value) {
+    auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(value.getType());
+    if (!tensorType)
+      return nullptr;
+    InferTypeLattice *lattice = getLatticeElement(value);
+    lattice->getValue().unsafeSet(InferTypeLatticeStorage(tensorType));
+    propagateIfChanged(lattice, mlir::ChangeResult::Change);
+    return lattice;
+  }
+
+  // Initialize lattice instances for results of the given op.
+  void initForResults(mlir::Operation *op) {
+    for (mlir::Value result : op->getResults())
+      initForValue(result);
+  }
+
+  // Initialize lattice instances for block arguments of the given block.
+  void initForBlockArguments(mlir::Block &block) {
+    for (mlir::Value arg : block.getArguments())
+      initForValue(arg);
+  }
+};
+
+// Dataflow analysis propagating type/shape information from results back to
+// operands. This is an optimistic sparse context-insensitive backward dataflow
+// analysis intended for intra-procedural use and composition with the
+// equivalent forward analysis. It starts by initializing a lattice instance
+// for all wave tensor-typed operands to their current type and propagates shape
+// information across operations using WaveInferTypeOpInterface as well as
+// across control flow using regular control flow interfaces until convergence.
+// In case of a type inference conflict, e.g. the pre-existing type is different
+// from the type inferred by dataflow, a diagnostic is emitted and the lattice
+// instance corresponding to the value with type conflict is set to the top
+// state. If the analysis fails due to the lack of information, e.g., control
+// flow operations not implementing the requested interfaces, the lattice
+// instances may be set to the top state without diagnostics.
+class InferTypeBackwardAnalysis
+    : public mlir::dataflow::SparseBackwardDataFlowAnalysis<InferTypeLattice> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  // Forcibly initializes lattice instances for wave tensor-typed function
+  // terminator operands to their current type.
+  //
+  // XXX: this works since we never revisit the function exit blocks again in
+  // the intra-procedural case. Without this function, the framework would
+  // call `setToEntryState` that would trigger setting to lattice top which we
+  // don't want.
+  mlir::LogicalResult initialize(mlir::Operation *top) override {
+    if (getSolverConfig().isInterprocedural())
+      return top->emitError() << "interprocedural analysis not supported";
+
+    if (mlir::failed(SparseBackwardDataFlowAnalysis::initialize(top)))
+      return mlir::failure();
+
+    // Call the base class initialization in order to set up update listeners.
+    // Note that this will initialize values at function/region entries to
+    // lattice top.
+    top->walk([this](mlir::Operation *op) {
+      if (!op->hasTrait<mlir::OpTrait::ReturnLike>())
+        return;
+      if (!llvm::isa<mlir::FunctionOpInterface>(op->getParentOp()))
+        return;
+      for (mlir::Value operand : op->getOperands()) {
+        auto tensorType =
+            llvm::dyn_cast<wave::WaveTensorType>(operand.getType());
+        if (!tensorType)
+          continue;
+        InferTypeLattice *lattice = getLatticeElement(operand);
+        lattice->getValue().unsafeSet(InferTypeLatticeStorage(tensorType));
+      }
+    });
+    return mlir::success();
+  }
+
+  // Called by base class initialization and when the analysis fails to identify
+  // lattices to join.
+  void setToExitState(InferTypeLattice *lattice) override {
+    propagateIfChanged(lattice, lattice->join(InferTypeLatticeStorage::top()));
+  }
+
+  // Dataflow transfer function, defers to the WaveInferTypeOpInterface.
+  mlir::LogicalResult
+  visitOperation(mlir::Operation *op,
+                 llvm::ArrayRef<InferTypeLattice *> operands,
+                 llvm::ArrayRef<const InferTypeLattice *> results) override {
+    std::optional<mlir::LogicalResult> res = handleNonInterfaceOp(op);
+    if (res)
+      return *res;
+
+    auto extractType = [](const InferTypeLattice *lattice) {
+      return lattice->getValue().getConcreteValue();
+    };
+    llvm::SmallVector<wave::WaveTensorType> operandTypes =
+        llvm::map_to_vector(operands, extractType);
+    llvm::SmallVector<wave::WaveTensorType> resultTypes =
+        llvm::map_to_vector(results, extractType);
+
+    std::string errorMessage;
+    llvm::raw_string_ostream errs(errorMessage);
+    llvm::FailureOr<mlir::ChangeResult> result =
+        llvm::cast<wave::WaveInferTypeOpInterface>(op).propagateBackward(
+            operandTypes, resultTypes, errs);
+    if (mlir::failed(result)) {
+      return op->emitError()
+             << "failed to propagate type information backward: " << errs.str();
+    }
+    if (*result == mlir::ChangeResult::NoChange)
+      return mlir::success();
+
+    for (auto &&[operand, lattice] : llvm::zip_equal(operandTypes, operands)) {
+      propagateIfChanged(lattice,
+                         lattice->join(InferTypeLatticeStorage(operand)));
+    }
+    return mlir::success();
+  }
+
+  // Specialization of the dataflow transfer function for control flow branch
+  // operation that are not forwarded to the branching target, so they cannot be
+  // backpropagated from there. We do not expect this to happen so move the
+  // lattice instance to the top state, indicating a if this ever happens.
+  void visitBranchOperand(mlir::OpOperand &opOperand) override {
+    auto tensorType =
+        llvm::dyn_cast<wave::WaveTensorType>(opOperand.get().getType());
+    if (!tensorType)
+      return;
+    InferTypeLattice *lattice = getLatticeElement(opOperand.get());
+    propagateIfChanged(lattice, lattice->join(InferTypeLatticeStorage::top()));
+  }
+
+  // Specialization of the dataflow transfer function for call operands that are
+  // not forwarded to the callee. We expect types to be fully specified at the
+  // function boundary so just set to the type.
+  void visitCallOperand(mlir::OpOperand &opOperand) override {
+    auto tensorType =
+        llvm::dyn_cast<wave::WaveTensorType>(opOperand.get().getType());
+    if (!tensorType)
+      return;
+    assert(tensorType.getFullySpecified() &&
+           "expected fully-specified types at the call boundary");
+    InferTypeLattice *lattice = getLatticeElement(opOperand.get());
+    propagateIfChanged(lattice,
+                       lattice->join(InferTypeLatticeStorage(tensorType)));
+  }
+};
+
+// Type inference pass implementation.
+class InferTypes : public wave::impl::WaterWaveInferTypesPassBase<InferTypes> {
+public:
+  using WaterWaveInferTypesPassBase::WaterWaveInferTypesPassBase;
+
+  void runOnOperation() override {
+    // Configure the analyses. The dead code and SCP analyses are required by
+    // the logic of the solver currently.
+    mlir::SymbolTableCollection symbolTable;
+    mlir::DataFlowConfig dataFlowConfig;
+    dataFlowConfig.setInterprocedural(false);
+    mlir::DataFlowSolver solver(dataFlowConfig);
+    solver.load<mlir::dataflow::DeadCodeAnalysis>();
+    solver.load<mlir::dataflow::SparseConstantPropagation>();
+    solver.load<InferTypeForwardAnalysis>();
+    solver.load<InferTypeBackwardAnalysis>(symbolTable);
+    mlir::Operation *root = getOperation();
+
+    // Run the dataflow analyses and capture whether some diagnostics were
+    // emitted. Only emitted a generic diagnostic if no more specific diagnostic
+    // was emitted. This is usually indicative of some deep internal problem in
+    // the dataflow solver.
+    bool emittedError = false;
+    mlir::DiagnosticEngine::HandlerID handlerID =
+        getContext().getDiagEngine().registerHandler(
+            [&](mlir::Diagnostic &diag) {
+              if (diag.getSeverity() == mlir::DiagnosticSeverity::Error)
+                emittedError = true;
+
+              // Returning failure indicates that the diagnostic wan't handled
+              // and it is forwarded to other registered handlers.
+              return mlir::failure();
+            });
+    if (mlir::failed(solver.initializeAndRun(root))) {
+      if (!emittedError)
+        getOperation()->emitError() << "dataflow analysis failed";
+      if (!force)
+        return signalPassFailure();
+    }
+    getContext().getDiagEngine().eraseHandler(handlerID);
+
+    // Update the type of the value given the lattice. Don't return failure
+    // after emitting error if force-processing is requested.
+    auto updateType = [&](mlir::Value value, llvm::StringRef description) {
+      if (!llvm::isa<wave::WaveTensorType>(value.getType()))
+        return mlir::success();
+
+      auto *lattice = solver.lookupState<InferTypeLattice>(value);
+      if (!lattice || lattice->getValue().isBottom()) {
+        emitError(value.getLoc()) << "couldn't infer type for " << description;
+        return mlir::failure(!force);
+      }
+      if (lattice->getValue().isTop()) {
+        emitError(value.getLoc())
+            << "type conflict was detected for " << description;
+        return mlir::failure(!force);
+      }
+
+      value.setType(lattice->getValue().getConcreteValue());
+      return mlir::success();
+    };
+
+    // Walk over all value definitions (op results and block arguments) and
+    // directly set their types to ones using the inferred shape. Report error
+    // and stop if any type failed to infer. Inferred types are supposed to
+    // still be accepted by the op verifiers that will normally run after the
+    // pass.
+    mlir::WalkResult walkResult =
+        getOperation()->walk([&](mlir::Operation *op) {
+          for (mlir::OpResult res : op->getResults()) {
+            if (mlir::failed(updateType(
+                    res, "result #" + std::to_string(res.getResultNumber()))))
+              return mlir::WalkResult::interrupt();
+          }
+
+          for (mlir::Region &region : op->getRegions()) {
+            for (auto &&[blockNumber, block] : llvm::enumerate(region)) {
+              for (mlir::BlockArgument arg : block.getArguments()) {
+                auto fmt = llvm::formatv(
+                    "argument #{0} of block #{1} in region #{2}",
+                    arg.getArgNumber(), blockNumber, region.getRegionNumber());
+                if (mlir::failed(updateType(arg, fmt.str())))
+                  return mlir::WalkResult::interrupt();
+              }
+            }
+          }
+
+          return mlir::WalkResult::advance();
+        });
+
+    if (walkResult.wasInterrupted())
+      return signalPassFailure();
+  }
+};
+} // namespace

--- a/test/Dialect/Wave/infer-types-force.mlir
+++ b/test/Dialect/Wave/infer-types-force.mlir
@@ -1,0 +1,18 @@
+// RUN: water-opt %s --water-wave-infer-types='force=1' --split-input-file --verify-diagnostics
+
+// expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
+func.func @iterate_conflict(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{type conflict was detected for result #0}}
+  %0 = wave.iterate @I iter_args(%arg0) {
+  // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
+  ^bb0(%arg1: !wave.tensor<[@A] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> (!wave.tensor<any of f32>)
+  // expected-error @below {{type conflict was detected for result #0}}
+  wave.iterate @I iter_args(%0) {
+  // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
+  ^bb0(%arg1: !wave.tensor<any of f32>):
+    wave.yield %arg1 : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>) -> (!wave.tensor<[@B] of f32>)
+  return
+}

--- a/test/Dialect/Wave/infer-types.mlir
+++ b/test/Dialect/Wave/infer-types.mlir
@@ -1,0 +1,181 @@
+// RUN: water-opt %s --water-wave-infer-types --split-input-file --verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: @propagate_forward
+func.func @propagate_forward(%a: !wave.tensor<[@A, @B] of bf16>) {
+  // CHECK: (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  wave.add %a, %a : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<any of bf16>
+  return
+}
+
+// CHECK-LABEL: @propagate_backward
+func.func @propagate_backward() {
+  %b = water_test.wave_tensor : !wave.tensor<any of bf16>
+  // CHECK: (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  wave.add %b, %b : (!wave.tensor<any of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return
+}
+
+// CHECK-LABEL: @propagate_control_flow
+func.func @propagate_control_flow(%a: !wave.tensor<[@A] of f32>, %b: !wave.tensor<[@A] of f32>, %c: i1) {
+  cf.cond_br %c, ^bb0(%a: !wave.tensor<[@A] of f32>), ^bb1(%b: !wave.tensor<[@A] of f32>)
+
+^bb0(%arg0: !wave.tensor<[@A] of f32>):
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %arg0: (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  return
+
+^bb1(%arg1: !wave.tensor<[@A] of f32>):
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %arg1: (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  return
+}
+
+// CHECK-LABEL: @propagate_control_flow_block
+func.func @propagate_control_flow_block(%a: !wave.tensor<[@A] of f32>) {
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  %b = wave.exp2 %a: (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+  cf.br ^bb0(%b: !wave.tensor<any of f32>)
+
+// CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>):
+^bb0(%arg0: !wave.tensor<any of f32>):
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %arg0: (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+  return
+}
+
+// CHECK-LABEL: @propagate_control_flow_backward
+func.func @propagate_control_flow_backward() {
+  // CHECK: !wave.tensor<[@C] of f32>
+  %b = water_test.wave_tensor : !wave.tensor<any of f32>
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@C] of f32>)
+  cf.br ^bb0(%b: !wave.tensor<any of f32>)
+
+// CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@C] of f32>):
+^bb0(%arg0: !wave.tensor<any of f32>):
+  // CHECK: (!wave.tensor<[@C] of f32>) -> !wave.tensor<[@C] of f32>
+  wave.exp2 %arg0: (!wave.tensor<any of f32>) -> !wave.tensor<[@C] of f32>
+  return
+}
+
+// CHECK-LABEL: @propagate_structured_control_flow
+func.func @propagate_structured_control_flow(%a: !wave.tensor<[@A] of f32>) {
+  %0 = wave.iterate @I iter_args(%a) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+  ^bb0(%arg0: !wave.tensor<any of f32>):
+    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+    // CHECK: !wave.tensor<[@A] of f32>
+    wave.yield %m : !wave.tensor<any of f32>
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+  return
+}
+
+// CHECK-LABEL: @propagate_structured_control_partial
+func.func @propagate_structured_control_partial(%a: !wave.tensor<[@A] of f32>) {
+  %0 = wave.iterate @I iter_args(%a) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+  ^bb0(%arg0: !wave.tensor<any of f32>):
+    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[@A] of f32>
+    // CHECK: !wave.tensor<[@A] of f32>
+    wave.yield %m : !wave.tensor<[@A] of f32>
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %0 : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  return
+}
+
+// CHECK-LABEL: @propagate_structured_control_pre
+func.func @propagate_structured_control_pre(%a: !wave.tensor<[@A] of f32>) {
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  %b = wave.exp2 %a : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  %0 = wave.iterate @I iter_args(%b) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+  ^bb0(%arg0: !wave.tensor<any of f32>):
+    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+    // CHECK: !wave.tensor<[@A] of f32>
+    wave.yield %m : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+  return
+}
+
+// CHECK-LABEL: @propagate_structured_control_backward
+func.func @propagate_structured_control_backward() {
+  // CHECK: !wave.tensor<[@A] of f32>
+  %b = water_test.wave_tensor : !wave.tensor<any of f32>
+  %0 = wave.iterate @I iter_args(%b) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+  ^bb0(%arg0: !wave.tensor<any of f32>):
+    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+    // CHECK: !wave.tensor<[@A] of f32>
+    wave.yield %m : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<[@A] of f32>
+  return
+}
+
+// -----
+
+func.func @conflict(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{failed to propagate type information backward: irreconcilable types during type inference from results(!wave.tensor<[@B] of f32>) to operands(!wave.tensor<[@A] of f32>) for results #0}}
+  %0 = wave.exp2 %arg0 : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+  wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<[@B] of f32>
+  return
+}
+
+// -----
+
+func.func @iterate_conflict(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{type conflict was detected for result #0}}
+  %0 = wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> (!wave.tensor<any of f32>)
+  wave.iterate @I iter_args(%0) {
+  ^bb0(%arg1: !wave.tensor<any of f32>):
+    wave.yield %arg1 : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>) -> (!wave.tensor<[@B] of f32>)
+  return
+}
+
+// -----
+
+func.func @force_fail_forward(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{failed to propagate type information forward: intentionally failed to propagate forward}}
+  water_test.wave_fail_propagation %arg0, %arg0 {forward}
+    : (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+    -> (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+  return
+}
+
+// -----
+
+func.func @force_fail_backward(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{failed to propagate type information backward: intentionally failed to propagate backward}}
+  water_test.wave_fail_propagation %arg0, %arg0 {backward}
+    : (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+    -> (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+  return
+}
+
+// -----
+
+func.func @type_mismatch_operands(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<[@B] of f32>) {
+  // This op intentionally doesn't have a verifier for shape matching so we can
+  // see the failure coming from the analysis/interface trait.
+  // expected-error @below {{ailed to propagate type information backward: irreconcilable types during type inference from results(!wave.tensor<[@A] of f32>) to operands(!wave.tensor<[@B] of f32>) for results #1}}
+  water_test.wave_fail_propagation %arg0, %arg1
+    : (!wave.tensor<[@A] of f32>, !wave.tensor<[@B] of f32>)
+    -> (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+  return
+}

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(Dialect)
 add_subdirectory(Transforms)

--- a/test/lib/Dialect/CMakeLists.txt
+++ b/test/lib/Dialect/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(LLVM_TARGET_DEFINITIONS WaterTestDialect.td)
+mlir_tablegen(WaterTestDialect.h.inc -gen-dialect-decls -dialect=water_test)
+mlir_tablegen(WaterTestDialect.cpp.inc -gen-dialect-defs -dialect=water_test)
+mlir_tablegen(WaterTestDialectOps.h.inc -gen-op-decls)
+mlir_tablegen(WaterTestDialectOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRWaterTestDialectIncGen)
+
+add_mlir_library(MLIRWaterTestDialect
+  WaterTestDialect.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+
+  DEPENDS
+  MLIRWaterTestDialectIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRWaveDialect
+)
+
+target_include_directories(MLIRWaterTestDialect
+  PRIVATE
+  ${PROJECT_BINARY_DIR}/test/lib/Dialect
+)

--- a/test/lib/Dialect/WaterTestDialect.cpp
+++ b/test/lib/Dialect/WaterTestDialect.cpp
@@ -1,0 +1,54 @@
+// Copyright 2025 The Water Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "WaterTestDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpImplementation.h"
+
+#include "WaterTestDialect.cpp.inc"
+
+void mlir::water::test::WaterTestDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "WaterTestDialectOps.cpp.inc"
+      >();
+};
+
+namespace mlir::water::test {
+void registerWaterTestDialect(DialectRegistry &registry) {
+  registry.insert<WaterTestDialect>();
+}
+} // namespace mlir::water::test
+
+using namespace mlir::water::test;
+
+llvm::FailureOr<mlir::ChangeResult> WaveFailPropagationOp::propagateForward(
+    llvm::ArrayRef<::wave::WaveTensorType> operandTypes,
+    llvm::MutableArrayRef<::wave::WaveTensorType> resultTypes,
+    llvm::raw_ostream &errs) {
+  if (getForward()) {
+    errs << "intentionally failed to propagate forward";
+    return mlir::failure();
+  }
+  return wave::detail::identityTypeInferencePropagate(
+      operandTypes, resultTypes, "operands", "results", errs);
+}
+
+llvm::FailureOr<mlir::ChangeResult> WaveFailPropagationOp::propagateBackward(
+    llvm::MutableArrayRef<::wave::WaveTensorType> operandTypes,
+    llvm::ArrayRef<::wave::WaveTensorType> resultTypes,
+    llvm::raw_ostream &errs) {
+  if (getBackward()) {
+    errs << "intentionally failed to propagate backward";
+    return mlir::failure();
+  }
+  return wave::detail::identityTypeInferencePropagate(
+      resultTypes, operandTypes, "results", "operands", errs);
+}
+
+#define GET_OP_CLASSES
+#include "WaterTestDialectOps.cpp.inc"

--- a/test/lib/Dialect/WaterTestDialect.h
+++ b/test/lib/Dialect/WaterTestDialect.h
@@ -1,0 +1,21 @@
+// Copyright 2025 The Water Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef WATER_TEST_LIB_DIALECT_WATERTESTDIALECT_H
+#define WATER_TEST_LIB_DIALECT_WATERTESTDIALECT_H
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/OpDefinition.h"
+#include "water/Dialect/Wave/IR/WaveInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveTypes.h"
+
+#include "WaterTestDialect.h.inc"
+#include "mlir/IR/Dialect.h"
+
+#define GET_OP_CLASSES
+#include "WaterTestDialectOps.h.inc"
+
+#endif // WATER_TEST_LIB_DIALECT_WATERTESTDIALECT_H

--- a/test/lib/Dialect/WaterTestDialect.td
+++ b/test/lib/Dialect/WaterTestDialect.td
@@ -1,0 +1,40 @@
+// Copyright 2025 The Water Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "water/Dialect/Wave/IR/WaveInterfaces.td"
+include "water/Dialect/Wave/IR/WaveTypes.td"
+
+#ifndef WATER_TEST_LIB_DIALECT_WATERTESTDIALECT
+#define WATER_TEST_LIB_DIALECT_WATERTESTDIALECT
+
+def WaterTestDialect : Dialect {
+  let name = "water_test";
+  let summary = "Dialect for testing Water";
+  let cppNamespace = "::mlir::water::test";
+}
+
+def WaveTensorOp
+    : Op<WaterTestDialect, "wave_tensor",
+         [WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait]> {
+  let results = (outs WaveTensorType:$result);
+  let assemblyFormat = "attr-dict `:` qualified(type($result))";
+}
+
+def WaveFailPropagationOp
+  : Op<WaterTestDialect, "wave_fail_propagation",
+       [DeclareOpInterfaceMethods<WaveInferTypeOpInterface>]> {
+  let arguments = (ins WaveTensorType:$in1,
+                       WaveTensorType:$in2,
+                       UnitAttr:$forward,
+                       UnitAttr:$backward);
+  let results = (outs WaveTensorType:$out1,
+                      WaveTensorType:$out2);
+  let assemblyFormat = "$in1 `,` $in2 attr-dict `:` functional-type(operands, results)";
+}
+
+#endif // WATER_TEST_LIB_DIALECT_WATERTESTDIALECT

--- a/tools/water-opt/CMakeLists.txt
+++ b/tools/water-opt/CMakeLists.txt
@@ -4,10 +4,12 @@ set(LIBS
         ${dialect_libs}
         ${conversion_libs}
         MLIRArithDialect
-        MLIRLowerWaveTransforms
         MLIROptLib
         MLIRWaterTransforms
+        MLIRWaveTransforms
+
         MLIRWaterTestTransforms
+        MLIRWaterTestDialect
 )
 
 add_llvm_executable(water-opt

--- a/tools/water-opt/water-opt.cpp
+++ b/tools/water-opt/water-opt.cpp
@@ -32,13 +32,13 @@
 // headers.
 namespace mlir::water::test {
 void registerAllPasses();
+void registerWaterTestDialect(DialectRegistry &registry);
 } // namespace mlir::water::test
 
 int main(int argc, char **argv) {
   mlir::water::registerPasses();
   mlir::water::test::registerAllPasses();
   wave::registerPasses();
-
   mlir::arith::registerArithIntRangeOptsPass();
   mlir::registerCanonicalizerPass();
   mlir::registerCSEPass();
@@ -52,6 +52,8 @@ int main(int argc, char **argv) {
                   mlir::LLVM::LLVMDialect, mlir::memref::MemRefDialect,
                   mlir::scf::SCFDialect, mlir::vector::VectorDialect,
                   wave::WaveDialect>();
+
+  mlir::water::test::registerWaterTestDialect(registry);
 
   return mlir::asMainReturnCode(
       WaterOptMain(argc, argv, "water optimizer driver\n", registry));


### PR DESCRIPTION
Introduce a dataflow-based pass for inferring shapes of tensors in the
wave dialect. The pass simultaneously performs sparse forward and
backward dataflow analysis propagating known shapes of wave tensors
across operations. Details of propagation for wave dialect operations
are deferred to each operation via an interface letting it define
forward and backward transfer functions. A couple of traits are
predefined with default implementation of the interface methods for most
common cases.

Wrapping the process in the dataflow framework provides convergence and
soundness guarantees assuming transfer functions are monotonous and
sound. This in turn allows one to easily detect and report shape
conflicts in the dialect.