### PR TITLE
MLIR op definitions for MoE-relevant kernels

### DIFF
--- a/include/water/Dialect/Wave/IR/CMakeLists.txt
+++ b/include/water/Dialect/Wave/IR/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_custom_target(MLIRWaveIncGen)
 
 set(LLVM_TARGET_DEFINITIONS WaveAttrs.td)
+mlir_tablegen(WaveEnums.h.inc -gen-enum-decls)
+mlir_tablegen(WaveEnums.cpp.inc -gen-enum-defs)
 mlir_tablegen(WaveAttrs.h.inc -gen-attrdef-decls)
 mlir_tablegen(WaveAttrs.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(MLIRWaveAttrsIncGen)

--- a/include/water/Dialect/Wave/IR/WaveAttrs.h
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.h
@@ -8,7 +8,9 @@
 #define WATER_DIALECT_WAVE_IR_WAVEATTRS_H
 
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
+#include "water/Dialect/Wave/IR/WaveEnums.h.inc"
 #define GET_ATTRDEF_CLASSES
 #include "water/Dialect/Wave/IR/WaveAttrs.h.inc"
 

--- a/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -9,6 +9,65 @@
 
 include "water/Dialect/Wave/IR/WaveDialect.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+//-----------------------------------------------------------------------------
+// Address space enum and attribute
+//-----------------------------------------------------------------------------
+
+def WaveAddressSpaceEnum
+    : I32EnumAttr<"WaveAddressSpace", "Where the tensor is located", [
+  I32EnumAttrCase<"Unspecified", 0, "unspecified">,
+  I32EnumAttrCase<"Global", 1, "global">,
+  I32EnumAttrCase<"Shared", 2, "shared">,
+  I32EnumAttrCase<"Register", 3, "register">,
+]> {
+  let cppNamespace = "::wave";
+  let genSpecializedAttr = 0;
+}
+
+def WaveAddressSpaceAttr
+    : EnumAttr<WaveDialect, WaveAddressSpaceEnum, "address_space"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+//-----------------------------------------------------------------------------
+// MMA kind enum and attribute
+//-----------------------------------------------------------------------------
+
+def WaveMmaKindEnum
+    : I32EnumAttr<"WaveMmaKind",
+                  "Matrix multiply/accumulate module configuration", [
+  // Configurations introduced in CDNA1.
+  I32EnumAttrCase<"F32_16x16x16_F16", 0x1020, "f32_16x16x16_f16">,
+  I32EnumAttrCase<"F32_32x32x8_F16", 0x1021, "f32_32x32x8_f16">,
+  I32EnumAttrCase<"F32_16x16x32_K8_F16", 0x1022, "f32_16x16x32_k8_f16">,
+  I32EnumAttrCase<"F32_32x32x16_K8_F16", 0x1023, "f32_32x32x16_k8_f16">,
+  I32EnumAttrCase<"I32_16x16x16_I8", 0x10C0, "i32_16x16x16_i8">,
+  I32EnumAttrCase<"I32_32x32x8_I8", 0x10C1, "i32_32x32x8_i8">,
+
+  // Configurations introduced in CDNA3.
+  I32EnumAttrCase<"F32_16x16x32_F8", 0x1230, "f32_16x16x32_f8">,
+  I32EnumAttrCase<"F32_32x32x16_F8", 0x1231, "f32_32x32x16_f8">,
+  I32EnumAttrCase<"F32_16x16x32_K4_F8", 0x1232, "f32_16x16x32_k4_f8">,
+  I32EnumAttrCase<"F32_32x32x16_K4_F8", 0x1233, "f32_32x32x16_k4_f8">,
+  I32EnumAttrCase<"I32_16x16x32_I8", 0x12C0, "i32_16x16x32_i8">,
+  I32EnumAttrCase<"I32_32x32x16_I8", 0x12C1, "i32_32x32x16_i8">,
+
+  // Configurations introduced in CDNA4.
+  I32EnumAttrCase<"F32_16x16x128_F8F6F4", 0x1340, "f32_16x16x128_f8f6f4">,
+  I32EnumAttrCase<"F32_32x32x64_F8F6F4", 0x1341, "f32_32x32x64_f8f6f4">
+]> {
+  let cppNamespace = "::wave";
+  let genSpecializedAttr = 0;
+}
+
+def WaveMmaKindAttr : EnumAttr<WaveDialect, WaveMmaKindEnum, "mma_kind"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+//-----------------------------------------------------------------------------
+// Other attributes
+//-----------------------------------------------------------------------------
 
 def WaveSymbolAttr : AttrDef<WaveDialect, "WaveSymbol"> {
   let mnemonic = "symbol";

--- a/include/water/Dialect/Wave/IR/WaveOps.h
+++ b/include/water/Dialect/Wave/IR/WaveOps.h
@@ -7,7 +7,9 @@
 #ifndef WATER_DIALECT_WAVE_IR_WAVEOPS_H
 #define WATER_DIALECT_WAVE_IR_WAVEOPS_H
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "water/Dialect/Wave/IR/WaveTypes.h"
 
 #define GET_OP_CLASSES

--- a/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/include/water/Dialect/Wave/IR/WaveOps.td
@@ -4,28 +4,222 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+include "water/Dialect/Wave/IR/WaveAttrs.td"
 include "water/Dialect/Wave/IR/WaveDialect.td"
 include "water/Dialect/Wave/IR/WaveTypes.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 #ifndef WATER_DIALECT_WAVE_WAVEOPS
 #define WATER_DIALECT_WAVE_WAVEOPS
 
-def MmaOp : Op<WaveDialect, "mma"> {
-  let summary = "Matrix multiply and accumulate";
+//-----------------------------------------------------------------------------
+// Base classes for arithmetic operations
+//-----------------------------------------------------------------------------
 
+class WaveArithmeticOpDoc {
+  string baseDescription = [{
+    Integer overflow and signedness as well as floating point fastmath semantics
+    are currently **UNDEFINED**.
+
+    All operands and results are expected to live in registers. Previous
+    operations must bring them to registers if needed.
+  }];
+}
+
+class UnaryWaveOp<string mnemonic>
+    : Op<WaveDialect, mnemonic>,
+      WaveArithmeticOpDoc {
   let arguments = (ins
-    Arg<WaveTensorType, "Left-hand side of the multiplication">:$lhs,
-    Arg<WaveTensorType, "Right-hand side of the multiplication">:$rhs,
-    Arg<WaveTensorType, "Accumulator for addition">:$accumulator
+    Arg<WaveTensorInRegister, "Argument">:$argument
   );
 
   let results = (outs
-    Res<WaveTensorType, "Accumulated result">:$result
+    Arg<WaveTensorInRegister, "Result">:$result
   );
 
-  let assemblyFormat = "$lhs `,` $rhs `,` $accumulator attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat =
+    "$argument attr-dict `:` functional-type(operands, results)";
+}
+
+class BinaryWaveOp<string mnemonic>
+    : Op<WaveDialect, mnemonic>,
+      WaveArithmeticOpDoc {
+  let arguments = (ins
+    Arg<WaveTensorInRegister, "Left-hand side">:$lhs,
+    Arg<WaveTensorInRegister, "Right-hand side">:$rhs
+  );
+
+  let results = (outs
+    Res<WaveTensorInRegister, "Result of the operation">:$result
+  );
+
+  let assemblyFormat =
+    "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
+}
+
+//-----------------------------------------------------------------------------
+// Arithmetic operations
+//-----------------------------------------------------------------------------
+
+def AddOp : BinaryWaveOp<"add"> {
+  let summary = "Add two values";
+  let description = baseDescription;
+}
+
+def MulOp : BinaryWaveOp<"mul"> {
+  let summary = "Multiply two values";
+  let description = baseDescription;
+}
+
+def DivOp : BinaryWaveOp<"div"> {
+  let summary = "Divide two values";
+  let description = baseDescription;
+}
+
+def Exp2Op : UnaryWaveOp<"exp2"> {
+  let summary = "Compute 2 to the power of the argument";
+  let description = baseDescription;
+}
+
+def MmaOp
+    : Op<WaveDialect, "mma">,
+      WaveArithmeticOpDoc {
+  let summary = "Matrix multiply and accumulate";
+  let description = baseDescription # [{
+    The mandatory `kind` attribute indicates which configuration to use in
+    emitting matrix core instructions. Operand and result tensors are expected
+    to have the corresponding elemental types. In particular, the first
+    component of the `kind`-s textual format indicates the accumulator and
+    result elemental type and the last component indicates the LHS/RHS elemental
+    type.
+  }];
+
+  let arguments = (ins
+    Arg<WaveTensorInRegister, "Left-hand side of the multiplication">:$lhs,
+    Arg<WaveTensorInRegister, "Right-hand side of the multiplication">:$rhs,
+    Arg<WaveTensorInRegister, "Accumulator for addition">:$accumulator,
+    Arg<WaveMmaKindAttr, "Kind of the MMA intrinsic to target">:$kind
+  );
+
+  let results = (outs
+    Res<WaveTensorInRegister, "Accumulated result">:$result
+  );
+
+  let assemblyFormat = "$lhs `,` $rhs `,` $accumulator attr-dict `:`"
+                       "functional-type(operands, results)";
   let hasVerifier = 1;
+}
+
+//-----------------------------------------------------------------------------
+// Control flow operations
+//-----------------------------------------------------------------------------
+
+def IterateOp : Op<WaveDialect, "iterate", [
+    DeclareOpInterfaceMethods<RegionBranchOpInterface,
+        ["areTypesCompatible", "getEntrySuccessorOperands"]>]> {
+  let summary = "Executes the body repeatedly";
+  let description = [{
+    Intrinsically sequential iterative execution that is akin to a loop with
+    bounds that are not yet specified. Instead, the iteration is understood to
+    be performed along the symbolic dimension that will later be instantiated to
+    a concrete value.
+
+    Similarly to other loop-like constructs, this operation uses secondary
+    induction variables for loop-carried values. The initial values are supplied
+    as `iter_args` and the resulting values are produced by `result`.
+  }];
+
+  let arguments = (ins
+    Arg<WaveSymbolAttr, "Iterator symbol">:$iterator,
+    Arg<Variadic<WaveTensorType>, "Carried values">:$iter_args
+  );
+
+  let results = (outs
+    Res<Variadic<WaveTensorType>, "Yielded values">:$results
+  );
+
+  let regions = (region
+    SizedRegion<1>:$body
+  );
+
+  let assemblyFormat =
+    "custom<SingleSymbol>($iterator) (`iter_args` `(` $iter_args^ `)`)?"
+    "attr-dict-with-keyword regions `:` functional-type(operands, results)";
+  let hasVerifier = 1;
+}
+
+def YieldOp : Op<WaveDialect, "yield",
+    [Terminator, HasParent<"::wave::IterateOp">,
+     DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>]> {
+  let summary = "Yields values from the current control flow context";
+
+  let arguments = (ins
+    Arg<Variadic<WaveTensorType>, "Yielded values">:$values
+  );
+
+  let assemblyFormat = "$values attr-dict `:` type($values)";
+}
+
+//-----------------------------------------------------------------------------
+// Memory-related operations
+//-----------------------------------------------------------------------------
+
+def ReadOp : Op<WaveDialect, "read"> {
+  let summary = "Reads from memory";
+  let description = [{
+    Moves data from a memory-resident tensor to a register-resident tensor
+    preserving the shape.
+  }];
+
+  let arguments = (ins
+    Arg<WaveTensorInMemory, "Tensor representing memory to read from">:$memory
+  );
+
+  let results = (outs
+    Res<WaveTensorInRegister, "Read value">:$result
+  );
+
+  let assemblyFormat =
+    "$memory attr-dict `:` functional-type(operands, results)";
+}
+
+def RegisterOp : Op<WaveDialect, "register"> {
+  let summary = "Defines a tensor value known to be placed in a register";
+  let description = [{
+    Defines a new register-resident tensor initialized with the given scalar
+    value. The (symbolic) shape of the tensor may be specified in the result
+    type.
+  }];
+
+  let arguments = (ins
+    Arg<Type<Or<[AnyInteger.predicate, AnyFloat.predicate]>>,
+        "Scalar value to initialize the tensor elements">:$init
+  );
+
+  let results = (outs
+    Res<WaveTensorInRegister, "Defined value">:$result
+  );
+
+  let assemblyFormat =
+    "$init attr-dict `:` custom<RegisterOpTypes>(type($init), type($result))";
+  let hasVerifier = 1;
+}
+
+def WriteOp : Op<WaveDialect, "write"> {
+  let summary = "Writes into memory";
+  let description = [{
+    Moves data from a register-resident tensor into a memory-resident tensor
+    preserving the shape.
+  }];
+
+  let arguments = (ins
+    Arg<WaveTensorInRegister, "Value to write">:$value_to_store,
+    Arg<WaveTensorInMemory, "Tensor representing memory to write into">:$memory
+  );
+
+  let assemblyFormat = "$value_to_store `,` $memory attr-dict `:`"
+                       "type($value_to_store) `,` type($memory)";
 }
 
 #endif // WATER_DIALECT_WAVE_WAVEOPS

--- a/include/water/Dialect/Wave/IR/WaveTypes.td
+++ b/include/water/Dialect/Wave/IR/WaveTypes.td
@@ -7,14 +7,21 @@
 #ifndef WATER_DIALECT_WAVE_WAVETYPES
 #define WATER_DIALECT_WAVE_WAVETYPES
 
+include "water/Dialect/Wave/IR/WaveAttrs.td"
 include "water/Dialect/Wave/IR/WaveDialect.td"
 include "mlir/IR/AttrTypeBase.td"
+
+//-----------------------------------------------------------------------------
+// Tensor type
+//-----------------------------------------------------------------------------
 
 def WaveTensorType : TypeDef<WaveDialect, "WaveTensor"> {
   let mnemonic = "tensor";
   let description = [{
     Tensor with symbolic shapes used in Wave dialects. The exact shape may be
-    unknown in the earlier stages and will be inferred later.
+    unknown in the earlier stages and will be inferred later. Tensors may have
+    an address space indicating whether the data is expected to live in a
+    certain location, including local data store (shared memory) and registers.
   }];
 
   let parameters = (ins
@@ -27,21 +34,66 @@ def WaveTensorType : TypeDef<WaveDialect, "WaveTensor"> {
     ArrayRefParameter<
       "::wave::WaveSymbolAttr",
       "Shape of the tensor when fully inferred, missing otherwise">:$shape,
-    // "::wave::WaveSymbolAttr":$shape,
     TypeParameter<"bool", "">:$fully_specified,
-    TypeParameter<"::mlir::Type", "Type of the tensor elements">:$element_type
+    TypeParameter<"::mlir::Type", "Type of the tensor elements">:$element_type,
+    DefaultValuedParameter<
+        "::wave::WaveAddressSpaceAttr",
+        "::wave::WaveAddressSpaceAttr::get("
+            "$_ctxt, ::wave::WaveAddressSpace::Unspecified)",
+        "Where does the tensor live">:$address_space
   );
 
-  let assemblyFormat = "`<` custom<TensorShape>($shape, $fully_specified) `of` $element_type `>`";
+  let assemblyFormat =
+      "`<` custom<TensorShape>($shape, $fully_specified) `of` $element_type "
+      "(`,` $address_space^)? `>`";
   let genVerifyDecl = 1;
 
   let extraClassDeclaration = [{
     // Return the rank of the fully-specified tensor.
     size_t getRank() {
-      assert(getFullySpecified() && "requested rank of an under-specified tensor");
+      assert(getFullySpecified() &&
+             "requested rank of an under-specified tensor");
       return getShape().size();
+    }
+
+    // Return the address space.
+    ::wave::WaveAddressSpace getAddressSpaceValue() const {
+      return getAddressSpace().getValue();
     }
   }];
 }
+
+//-----------------------------------------------------------------------------
+// Predicates and constraints for tensor types with specific address spaces
+//-----------------------------------------------------------------------------
+
+def WaveTensorAddressSpaceUnspecified
+  : CPred<"::llvm::cast<::wave::WaveTensorType>($_self).getAddressSpaceValue()"
+          " == ::wave::WaveAddressSpace::Unspecified">;
+def WaveTensorAddressSpaceGlobal
+  : CPred<"::llvm::cast<::wave::WaveTensorType>($_self).getAddressSpaceValue()"
+          " == ::wave::WaveAddressSpace::Global">;
+def WaveTensorAddressSpaceShared
+  : CPred<"::llvm::cast<::wave::WaveTensorType>($_self).getAddressSpaceValue()"
+          " == ::wave::WaveAddressSpace::Shared">;
+def WaveTensorAddressSpaceRegister
+  : CPred<"::llvm::cast<::wave::WaveTensorType>($_self).getAddressSpaceValue()"
+          " == ::wave::WaveAddressSpace::Register">;
+
+def WaveTensorInRegister : TypeConstraint<
+  And<[WaveTensorType.predicate,
+       Or<[WaveTensorAddressSpaceUnspecified, WaveTensorAddressSpaceRegister]>]>,
+  "Wave tensor in register",
+  WaveTensorType.cppType
+>;
+
+def WaveTensorInMemory : TypeConstraint<
+  And<[WaveTensorType.predicate,
+       Or<[WaveTensorAddressSpaceUnspecified,
+           WaveTensorAddressSpaceGlobal,
+           WaveTensorAddressSpaceShared]>]>,
+  "Wave tensor in memory",
+  WaveTensorType.cppType
+>;
 
 #endif // WATER_DIALECT_WAVE_WAVETYPES

--- a/lib/Dialect/Wave/IR/CMakeLists.txt
+++ b/lib/Dialect/Wave/IR/CMakeLists.txt
@@ -9,4 +9,5 @@ add_mlir_dialect_library(MLIRWaveDialect
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRControlFlowInterfaces
 )

--- a/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/ADT/TypeSwitch.h"
 
+#include "water/Dialect/Wave/IR/WaveEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
 #include "water/Dialect/Wave/IR/WaveAttrs.cpp.inc"
 

--- a/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -7,10 +7,71 @@
 #include "water/Dialect/Wave/IR/WaveOps.h"
 
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveAttrs.h"
+#include "water/Dialect/Wave/IR/WaveTypes.h"
+#include "llvm/ADT/STLExtras.h"
+
+//-----------------------------------------------------------------------------
+// Custom parsing and printing hooks. These must be defined before including the
+// op classes.
+//-----------------------------------------------------------------------------
+
+// Parse types of the `wave.register` op and perform type inference. The syntax
+// is simply the tensor type from which the elemental type is extract for the
+// initializer type.
+static mlir::ParseResult parseRegisterOpTypes(mlir::OpAsmParser &parser,
+                                              mlir::Type &initType,
+                                              mlir::Type &resultType) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  if (mlir::failed(parser.parseType(resultType)))
+    return mlir::failure();
+
+  auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(resultType);
+  if (!tensorType)
+    return parser.emitError(loc)
+           << "expected wave tensor type, got " << resultType;
+
+  initType = tensorType.getElementType();
+  return mlir::success();
+}
+
+// Print types of the `wave.register` operation.
+static void printRegisterOpTypes(mlir::OpAsmPrinter &printer, mlir::Operation *,
+                                 mlir::Type initType, mlir::Type resultType) {
+  assert(initType ==
+             llvm::cast<wave::WaveTensorType>(resultType).getElementType() &&
+         "expected equal types");
+  (void)initType;
+  printer.printType(resultType);
+}
+
+// Parse an @-symbol and interpret it as a wave symbol.
+static mlir::ParseResult parseSingleSymbol(mlir::OpAsmParser &parser,
+                                           wave::WaveSymbolAttr &symbolAttr) {
+  mlir::StringAttr strAttr;
+  if (mlir::failed(parser.parseSymbolName(strAttr)))
+    return mlir::failure();
+
+  symbolAttr =
+      wave::WaveSymbolAttr::get(parser.getContext(), strAttr.getValue());
+  return mlir::success();
+}
+
+// Print a wave symbol as an MLIR @-symbol.
+static void printSingleSymbol(mlir::OpAsmPrinter &printer, mlir::Operation *,
+                              wave::WaveSymbolAttr symbolAttr) {
+  printer.printSymbolName(symbolAttr.getName());
+}
 
 #define GET_OP_CLASSES
 #include "water/Dialect/Wave/IR/WaveOps.cpp.inc"
+
+//-----------------------------------------------------------------------------
+// Verification helpers
+//-----------------------------------------------------------------------------
 
 // Update negative indices in the array to positive equivalents given the total
 // rank, e.g. -1 and -3 get updated to 3 and 1, respectively, for the rank of 4.
@@ -23,12 +84,14 @@ static void updateNegativeIndices(llvm::MutableArrayRef<int> indices,
 }
 
 // Verify that specified dimensions match between LHS and RHS, the lists of
-// dimensions are expected to be co-indexed. Emit diagnostic errors and return
-// failure when it is not the case.
-static mlir::LogicalResult verifyTypesMatchingDimensions(
-    mlir::Location loc, llvm::StringRef lhsName, wave::WaveTensorType lhs,
-    llvm::ArrayRef<int> lhsDims, llvm::StringRef rhsName,
-    wave::WaveTensorType rhs, llvm::ArrayRef<int> rhsDims) {
+// dimensions are expected to be co-indexed. Emit diagnostic errors and
+// return failure when it is not the case.
+static mlir::LogicalResult
+verifyTypesMatchingDimensions(std::optional<mlir::Location> loc,
+                              llvm::StringRef lhsName, wave::WaveTensorType lhs,
+                              llvm::ArrayRef<int> lhsDims,
+                              llvm::StringRef rhsName, wave::WaveTensorType rhs,
+                              llvm::ArrayRef<int> rhsDims) {
   // TODO: check whether it is possible to turn this into a trait.
 
   assert(lhsDims.size() == rhsDims.size() &&
@@ -47,43 +110,247 @@ static mlir::LogicalResult verifyTypesMatchingDimensions(
     if (lhsExpr == rhsExpr)
       continue;
 
-    return mlir::emitError(loc)
-           << "expected " << lhsName << " dimension #" << lhsDim << " ("
-           << lhsExpr << ") to match " << rhsName << " dimension #" << rhsDim
-           << " (" << rhsExpr << ")";
+    if (loc) {
+      mlir::emitError(*loc)
+          << "expected " << lhsName << " dimension #" << lhsDim << " ("
+          << lhsExpr << ") to match " << rhsName << " dimension #" << rhsDim
+          << " (" << rhsExpr << ")";
+    }
+    return mlir::failure();
   }
   return mlir::success();
 }
 
 // Verify that element types of Wave tensors match between LHS and RHS. Emit
 // diagnostic errors and return a failure when it is not the case.
-static mlir::LogicalResult verifyElementTypesMatch(mlir::Location loc,
-                                                   llvm::StringRef lhsName,
-                                                   wave::WaveTensorType lhs,
-                                                   llvm::StringRef rhsName,
-                                                   wave::WaveTensorType rhs) {
+static mlir::LogicalResult
+verifyElementTypesMatch(std::optional<mlir::Location> loc,
+                        llvm::StringRef lhsName, wave::WaveTensorType lhs,
+                        llvm::StringRef rhsName, wave::WaveTensorType rhs) {
   if (lhs.getElementType() == rhs.getElementType())
     return mlir::success();
 
+  if (loc) {
+    mlir::emitError(*loc) << "expected " << lhsName << " and " << rhsName
+                          << " elemental types to match, got "
+                          << lhs.getElementType() << ", "
+                          << rhs.getElementType();
+  }
+  return mlir::failure();
+}
+
+// Verify if two types are compatible:
+//   - their symbolic shapes are either equal or at least one of them is
+//     underspecified;
+//   - their address spaces are either equal or at least one of them is
+//     underspecified.
+// When it is not the case, return failure and optionally report an error if a
+// location is provided.
+static mlir::LogicalResult verifyTypesCompatible(
+    wave::WaveTensorType lhs, wave::WaveTensorType rhs,
+    bool includeAddressSpace,
+    std::optional<mlir::Location> errorLocation = std::nullopt,
+    llvm::StringRef lhsName = "", llvm::StringRef rhsName = "") {
+  // Fast and cheap path.
+  if (lhs == rhs)
+    return mlir::success();
+
+  if (errorLocation) {
+    assert(!lhsName.empty() && !rhsName.empty() &&
+           "expected names when location is provided");
+  }
+
+  if (includeAddressSpace) {
+    if (lhs.getAddressSpaceValue() != rhs.getAddressSpaceValue() &&
+        lhs.getAddressSpaceValue() != wave::WaveAddressSpace::Unspecified &&
+        rhs.getAddressSpaceValue() != wave::WaveAddressSpace::Unspecified) {
+      if (errorLocation) {
+        emitError(*errorLocation) << "address space mismatch between" << lhsName
+                                  << " and " << rhsName;
+      }
+      return mlir::failure();
+    }
+  }
+
+  if (mlir::failed(
+          verifyElementTypesMatch(errorLocation, lhsName, lhs, rhsName, rhs)))
+    return mlir::failure();
+
+  if (!lhs.getFullySpecified() || !rhs.getFullySpecified())
+    return mlir::success();
+
+  if (lhs.getRank() != rhs.getRank()) {
+    if (errorLocation) {
+      emitError(*errorLocation)
+          << "rank mismatch between " << lhsName << " and " << rhsName;
+    }
+    return mlir::failure();
+  }
+
+  auto allDims = llvm::to_vector(llvm::iota_range<int>(0, lhs.getRank(),
+                                                       /*Inclusive=*/false));
+  return verifyTypesMatchingDimensions(errorLocation, lhsName, lhs, allDims,
+                                       rhsName, rhs, allDims);
+}
+
+//-----------------------------------------------------------------------------
+// IterateOp
+//-----------------------------------------------------------------------------
+
+bool wave::IterateOp::areTypesCompatible(mlir::Type lhs, mlir::Type rhs) {
+  return verifyTypesCompatible(llvm::cast<wave::WaveTensorType>(lhs),
+                               llvm::cast<wave::WaveTensorType>(rhs),
+                               /*includeAddressSpace=*/true)
+      .succeeded();
+}
+
+mlir::OperandRange
+wave::IterateOp::getEntrySuccessorOperands(mlir::RegionBranchPoint point) {
+  return getIterArgs();
+}
+
+void wave::IterateOp::getSuccessorRegions(
+    mlir::RegionBranchPoint point,
+    ::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
+  // May branch into the region or bypass it regardless of the source.
+  regions.emplace_back(mlir::RegionSuccessor(getResults()));
+  regions.emplace_back(
+      mlir::RegionSuccessor(&getBody(), getBody().front().getArguments()));
+}
+
+mlir::LogicalResult wave::IterateOp::verify() {
+  mlir::TypeRange iterArgTypes = getIterArgs().getTypes();
+  mlir::TypeRange resultTypes = getResultTypes();
+  if (iterArgTypes.size() != resultTypes.size()) {
+    return emitOpError() << "expects the same number of iter_args ("
+                         << iterArgTypes.size() << ") and results ("
+                         << resultTypes.size() << ")";
+  }
+  for (auto &&[i, iterArg, result] :
+       llvm::enumerate(iterArgTypes, resultTypes)) {
+    auto iterArgTensor = llvm::cast<wave::WaveTensorType>(iterArg);
+    auto resultTensor = llvm::cast<wave::WaveTensorType>(result);
+    if (!iterArgTensor.getFullySpecified() || !resultTensor.getFullySpecified())
+      continue;
+
+    auto allDims =
+        llvm::to_vector(llvm::iota_range<int>(0, iterArgTensor.getRank(),
+                                              /*Inclusive=*/false));
+    auto istr = std::to_string(i);
+    if (mlir::failed(verifyTypesMatchingDimensions(
+            getLoc(), "iter_args #" + istr, iterArgTensor, allDims,
+            "result #" + istr, resultTensor, allDims)))
+      return mlir::failure();
+  }
+
+  return mlir::success();
+}
+
+//-----------------------------------------------------------------------------
+// MmaOp
+//-----------------------------------------------------------------------------
+
+// Check if the given type is one of the allowed types provided as template
+// arguments and report an error at the given location otherwise.
+template <typename... AllowedTypes>
+static mlir::LogicalResult
+checkAllowedTypes(mlir::Location loc, mlir::Type type, llvm::StringRef name,
+                  wave::WaveMmaKind kind) {
+  if (llvm::isa<AllowedTypes...>(type))
+    return mlir::success();
+
   return mlir::emitError(loc)
-         << "expected " << lhsName << " and " << rhsName
-         << " elemental types to match, got " << lhs.getElementType() << ", "
-         << rhs.getElementType();
+         << "unexpected " << name << " elemental type " << type
+         << " for MMA kind " << wave::stringifyEnum(kind);
+}
+
+// Check if the given type is an integer type with one of the provided bitwidths
+// and report and error at the given location otherwise.
+template <typename T>
+static std::enable_if_t<std::is_same_v<T, mlir::IntegerType>,
+                        mlir::LogicalResult>
+checkAllowedTypes(mlir::Location loc, mlir::Type type, llvm::StringRef name,
+                  wave::WaveMmaKind kind, llvm::ArrayRef<unsigned> bitwidths) {
+  if (auto intType = llvm::dyn_cast<mlir::IntegerType>(type)) {
+    if (llvm::is_contained(bitwidths, intType.getIntOrFloatBitWidth()))
+      return mlir::success();
+  }
+  return mlir::emitError(loc)
+         << "unexpected " << name << " elemental type " << type
+         << " for MMA kind " << wave::stringifyEnum(kind);
+}
+
+// Check if the types used for multiplication and accumulation in a `wave.mma`
+// operation are compatible with the specified MMA kind and report an error
+// otherwise.
+static mlir::LogicalResult checkMmaTypeCompatibility(mlir::Location loc,
+                                                     wave::WaveMmaKind kind,
+                                                     mlir::Type mulType,
+                                                     mlir::Type accType) {
+  bool success = false;
+  switch (kind) {
+  case wave::WaveMmaKind::F32_16x16x16_F16:
+  case wave::WaveMmaKind::F32_32x32x8_F16:
+  case wave::WaveMmaKind::F32_16x16x32_K8_F16:
+  case wave::WaveMmaKind::F32_32x32x16_K8_F16: {
+    success = mlir::succeeded(checkAllowedTypes<mlir::Float32Type>(
+                  loc, accType, "accumulator/result", kind)) &&
+              mlir::succeeded(
+                  checkAllowedTypes<mlir::Float16Type, mlir::BFloat16Type>(
+                      loc, mulType, "lhs/rhs", kind));
+    break;
+  }
+
+  case wave::WaveMmaKind::I32_16x16x16_I8:
+  case wave::WaveMmaKind::I32_32x32x8_I8:
+  case wave::WaveMmaKind::I32_16x16x32_I8:
+  case wave::WaveMmaKind::I32_32x32x16_I8:
+    success = mlir::succeeded(checkAllowedTypes<mlir::IntegerType>(
+                  loc, accType, "accumulator/result", kind, {32})) &&
+              mlir::succeeded(checkAllowedTypes<mlir::IntegerType>(
+                  loc, mulType, "lhs/rhs", kind, {8}));
+    break;
+
+  case wave::WaveMmaKind::F32_16x16x32_F8:
+  case wave::WaveMmaKind::F32_32x32x16_F8:
+  case wave::WaveMmaKind::F32_16x16x32_K4_F8:
+  case wave::WaveMmaKind::F32_32x32x16_K4_F8:
+    success = mlir::succeeded(checkAllowedTypes<mlir::Float32Type>(
+                  loc, accType, "accumulator/result", kind)) &&
+              mlir::succeeded(
+                  checkAllowedTypes<mlir::Float8E3M4Type, mlir::Float8E5M2Type>(
+                      loc, mulType, "lhs/rhs", kind));
+    break;
+
+  case wave::WaveMmaKind::F32_16x16x128_F8F6F4:
+  case wave::WaveMmaKind::F32_32x32x64_F8F6F4:
+    success =
+        mlir::succeeded(checkAllowedTypes<mlir::Float32Type>(
+            loc, accType, "accumulator/result", kind)) &&
+        mlir::succeeded(
+            checkAllowedTypes<mlir::Float8E3M4Type, mlir::Float8E5M2Type,
+                              mlir::Float6E2M3FNType, mlir::Float6E3M2FNType,
+                              mlir::Float4E2M1FNType>(loc, mulType, "lhs/rhs",
+                                                      kind));
+    break;
+  }
+
+  return mlir::success(success);
 }
 
 mlir::LogicalResult wave::MmaOp::verify() {
   WaveTensorType lhsType = getLhs().getType();
   WaveTensorType rhsType = getRhs().getType();
   WaveTensorType accumulatorType = getAccumulator().getType();
+  WaveTensorType resultType = getResult().getType();
 
   if (failed(
           verifyElementTypesMatch(getLoc(), "LHS", lhsType, "RHS", rhsType)) ||
-      failed(verifyElementTypesMatch(getLoc(), "LHS", lhsType, "accumulator",
-                                     accumulatorType)))
+      failed(verifyElementTypesMatch(getLoc(), "result", resultType,
+                                     "accumulator", accumulatorType)))
     return mlir::failure();
 
-  return mlir::failure(
-      verifyTypesMatchingDimensions(getLoc(), "LHS", lhsType, {1}, "RHS",
+  if (verifyTypesMatchingDimensions(getLoc(), "LHS", lhsType, {1}, "RHS",
                                     rhsType, {0})
           .failed() ||
       verifyTypesMatchingDimensions(getLoc(), "LHS", lhsType, {0},
@@ -91,5 +358,37 @@ mlir::LogicalResult wave::MmaOp::verify() {
           .failed() ||
       verifyTypesMatchingDimensions(getLoc(), "RHS", rhsType, {1},
                                     "accumulator", accumulatorType, {1})
-          .failed());
+          .failed()) {
+    return mlir::failure();
+  }
+
+  return checkMmaTypeCompatibility(getLoc(), getKind(),
+                                   lhsType.getElementType(),
+                                   accumulatorType.getElementType());
+}
+
+//-----------------------------------------------------------------------------
+// RegisterOp
+//-----------------------------------------------------------------------------
+
+mlir::LogicalResult wave::RegisterOp::verify() {
+  WaveTensorType tensorType = getResult().getType();
+  mlir::Type initType = getInit().getType();
+  if (tensorType.getElementType() != initType) {
+    return emitOpError() << "expected the type of the init value to match the "
+                            "elemental type of the tensor";
+  }
+  if (!tensorType.getFullySpecified()) {
+    return emitOpError() << "expected fully-specified tensor type";
+  }
+  return mlir::success();
+}
+
+//-----------------------------------------------------------------------------
+// YieldOp
+//-----------------------------------------------------------------------------
+
+mlir::MutableOperandRange
+wave::YieldOp::getMutableSuccessorOperands(mlir::RegionBranchPoint) {
+  return getValuesMutable();
 }

--- a/lib/Dialect/Wave/IR/WaveTypes.cpp
+++ b/lib/Dialect/Wave/IR/WaveTypes.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "water/Dialect/Wave/IR/WaveTypes.h"
+#include "water/Dialect/Wave/IR/WaveAttrs.h"
 #include "water/Dialect/Wave/IR/WaveDialect.h"
 
 #include "mlir/IR/Builders.h"
@@ -68,7 +69,7 @@ void wave::WaveDialect::registerTypes() {
 mlir::LogicalResult wave::WaveTensorType::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
     llvm::ArrayRef<wave::WaveSymbolAttr> shape, bool fullySpecified,
-    mlir::Type elementType) {
+    mlir::Type elementType, wave::WaveAddressSpaceAttr addressSpace) {
   if (!fullySpecified && !shape.empty()) {
     return emitError() << "shape not expected for non-fully specified tensors";
   }

--- a/test/Dialect/Wave/attr-type.mlir
+++ b/test/Dialect/Wave/attr-type.mlir
@@ -8,3 +8,12 @@ func.func private @foo() -> !wave.tensor<[@A, @B] of bf16>
 
 // CHECK: !wave.tensor<any of bf16>
 func.func private @unspecified_tensor() -> !wave.tensor<any of bf16>
+
+// CHECK: !wave.tensor<any of i32, <global>>
+func.func private @address_space() -> !wave.tensor<any of i32, <global>>
+
+// CHECK: !wave.tensor<any of i32, <global>>
+func.func private @address_space_full() -> !wave.tensor<any of i32, #wave.address_space<global>>
+
+// CHECK: !wave.tensor<any of i8>
+func.func private @address_space_default() -> !wave.tensor<any of i8, <unspecified>>

--- a/test/Dialect/Wave/ops-invalid.mlir
+++ b/test/Dialect/Wave/ops-invalid.mlir
@@ -1,34 +1,82 @@
 // RUN: water-opt %s --split-input-file --verify-diagnostics
 
 func.func @mismatch_element_lhs_acc(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of f32>, %acc: !wave.tensor<[@A, @C] of bf16>) {
-  // expected-error @below {{expected LHS and accumulator elemental types to match, got 'f32', 'bf16'}}
-  wave.mma %lhs, %rhs, %acc : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>, !wave.tensor<[@A, @C] of bf16>) -> !wave.tensor<[@A, @C] of bf16>
+  // expected-error @below {{unexpected accumulator/result elemental type 'bf16' for MMA kind f32_16x16x16_f16}}
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>, !wave.tensor<[@A, @C] of bf16>) -> !wave.tensor<[@A, @C] of bf16>
+}
+
+// -----
+
+func.func @mismatch_element_int(%lhs: !wave.tensor<[@A, @B] of i32>, %rhs: !wave.tensor<[@B, @C] of i32>, %acc: !wave.tensor<[@A, @C] of i32>) {
+  // expected-error @below {{unexpected lhs/rhs elemental type 'i32' for MMA kind i32_32x32x16_i8}}
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<i32_32x32x16_i8>} : (!wave.tensor<[@A, @B] of i32>, !wave.tensor<[@B, @C] of i32>, !wave.tensor<[@A, @C] of i32>) -> !wave.tensor<[@A, @C] of i32>
 }
 
 // -----
 
 func.func @mismatch_element_lhs_rhs(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of bf16>, %acc: !wave.tensor<[@A, @C] of f32>) {
   // expected-error @below {{expected LHS and RHS elemental types to match, got 'f32', 'bf16'}}
-  wave.mma %lhs, %rhs, %acc : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of bf16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of bf16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
 }
 
 // -----
 
-func.func @mismatch_dim_lhs_rhs(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@C, @B] of f32>, %acc: !wave.tensor<[@A, @C] of f32>) {
+func.func @mismatch_dim_lhs_rhs(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@C, @B] of f16>, %acc: !wave.tensor<[@A, @C] of f32>) {
   // expected-error @below {{expected LHS dimension #1 (#wave.symbol<"B">) to match RHS dimension #0 (#wave.symbol<"C">)}}
-  wave.mma %lhs, %rhs, %acc : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@C, @B] of f32>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@C, @B] of f16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
 }
 
 // -----
 
-func.func @mismatch_dim_lhs_acc(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of f32>, %acc: !wave.tensor<[@E, @D] of f32>) {
+func.func @mismatch_dim_lhs_acc(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@B, @C] of f16>, %acc: !wave.tensor<[@E, @D] of f32>) {
   // expected-error @below {{expected LHS dimension #0 (#wave.symbol<"A">) to match accumulator dimension #0 (#wave.symbol<"E">)}}
-  wave.mma %lhs, %rhs, %acc : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>, !wave.tensor<[@E, @D] of f32>) -> !wave.tensor<[@E, @D] of f32>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@B, @C] of f16>, !wave.tensor<[@E, @D] of f32>) -> !wave.tensor<[@E, @D] of f32>
 }
 
 // -----
 
-func.func @mismatch_dim_rhs_acc(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of f32>, %acc: !wave.tensor<[@A, @D] of f32>) {
+func.func @mismatch_dim_rhs_acc(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@B, @C] of f16>, %acc: !wave.tensor<[@A, @D] of f32>) {
   // expected-error @below {{expected RHS dimension #1 (#wave.symbol<"C">) to match accumulator dimension #1 (#wave.symbol<"D">)}}
-  wave.mma %lhs, %rhs, %acc : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>, !wave.tensor<[@A, @D] of f32>) -> !wave.tensor<[@A, @D] of f32>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@B, @C] of f16>, !wave.tensor<[@A, @D] of f32>) -> !wave.tensor<[@A, @D] of f32>
+}
+
+// -----
+
+func.func @invalid_register_type(%arg0: f32) {
+  // expected-error @below {{expected wave tensor type, got 'f32'}}
+  wave.register %arg0 : f32
+}
+
+// -----
+
+func.func @register_type_mismatch(%arg0: f32) {
+  // expected-error @below {{expected the type of the init value to match the elemental type of the tensor}}
+  "wave.register"(%arg0) : (f32) -> !wave.tensor<[@A, @B] of bf16>
+}
+
+// -----
+
+func.func @register_underspecified(%arg0: f32) {
+  // expected-error @below {{expected fully-specified tensor type}}
+  wave.register %arg0 : !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @iterate_mismatching_results(%arg0: !wave.tensor<any of f32>, %arg1: !wave.tensor<any of f32>) {
+  // expected-error @below {{expects the same number of iter_args (2) and results (1)}}
+  wave.iterate @I iter_args(%arg0, %arg1) {
+  ^bb0(%arg2: !wave.tensor<any of f32>, %arg3: !wave.tensor<any of f32>):
+    wave.yield %arg2 : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @iterate_mismatching_results(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<any of f32>) {
+  // expected-error @below {{along control flow edge from parent operands to Region #0: source type #0 '!wave.tensor<[@A] of f32>' should match input type #0 '!wave.tensor<[@B] of f32>'}}
+  wave.iterate @I iter_args(%arg0, %arg1) {
+  ^bb0(%arg2: !wave.tensor<[@B] of f32>, %arg3: !wave.tensor<any of f32>):
+    wave.yield %arg2, %arg3 : !wave.tensor<[@B] of f32>, !wave.tensor<any of f32>
+  } : (!wave.tensor<[@A] of f32>, !wave.tensor<any of f32>) -> (!wave.tensor<any of f32>, !wave.tensor<any of f32>)
 }

--- a/test/Dialect/Wave/ops.mlir
+++ b/test/Dialect/Wave/ops.mlir
@@ -1,8 +1,73 @@
-// RUN: water-opt %s --verify-diagnostics | FileCheck %s
+// RUN: water-opt %s | water-opt | FileCheck %s
+// RUN: water-opt %s --mlir-print-op-generic | water-opt | FileCheck %s
+
+//===---------------------------------------------------------------------------
+// The following tests basically check the presence of an operation in the
+// dialect. We don't need to check the syntax as it is auto-generated and the
+// generator is tested extensively.
+//===---------------------------------------------------------------------------
 
 // CHECK-LABEL: @mma
-func.func @mma(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of f32>, %acc: !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32> {
+func.func @mma(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@B, @C] of f16>, %acc: !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32> {
   // CHECK: wave.mma
-  %0 = wave.mma %lhs, %rhs, %acc : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
+  %0 = wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@B, @C] of f16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
   return %0 : !wave.tensor<[@A, @C] of f32>
+}
+
+// CHECK-LABEL: @unary
+func.func @unary(%value: !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16> {
+  // CHECK: wave.exp2
+  %0 = wave.exp2 %value : (!wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return %0 : !wave.tensor<[@A, @B] of bf16>
+}
+
+// CHECK-LABEL: @binary
+func.func @binary(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16> {
+  // CHECK: wave.add
+  %0 = wave.add %lhs, %rhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  // CHECK: wave.mul
+  %1 = wave.mul %0, %rhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  // CHECK: wave.div
+  %2 = wave.div %1, %lhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return %2 : !wave.tensor<[@A, @B] of bf16>
+}
+
+// CHECK-LABEL: @memory
+func.func @memory(%mem: !wave.tensor<[@X] of f32, <global>>) {
+  // CHECK: wave.read
+  %0 = wave.read %mem : (!wave.tensor<[@X] of f32, <global>>) -> !wave.tensor<any of f32, <register>>
+  // CHECK: wave.write
+  wave.write %0, %mem : !wave.tensor<any of f32, <register>>, !wave.tensor<[@X] of f32, <global>>
+  return
+}
+
+//===---------------------------------------------------------------------------
+// Operations with custom syntax elements.
+//===---------------------------------------------------------------------------
+
+// CHECK-LABEL: @iterate
+func.func @iterate(%input0: !wave.tensor<any of f32>, %input1: !wave.tensor<any of bf16>)
+    -> (!wave.tensor<any of f32>, !wave.tensor<any of bf16>) {
+  // Note that it is okay to have compatible but not equal types along internal
+  // control flow edges, i.e., the types of block arguments don't need to
+  // exactly match those of operands and the types of the terminator results
+  // don't need to exactly match those of iterate results as long as one of them
+  // is underspecified.
+  //
+  // CHECK: wave.iterate @I iter_args
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>, %{{.*}}: !wave.tensor<[@B] of bf16>):
+  %iter_result:2 = wave.iterate @I iter_args(%input0, %input1) {
+  ^bb0(%in_arg0: !wave.tensor<[@A] of f32>, %in_arg1: !wave.tensor<[@B] of bf16>):
+    // CHECK: wave.yield %{{.*}}, %{{.*}} : !wave.tensor<[@A] of f32>, !wave.tensor<[@B] of bf16>
+    wave.yield %in_arg0, %in_arg1 : !wave.tensor<[@A] of f32>, !wave.tensor<[@B] of bf16>
+  } : (!wave.tensor<any of f32>, !wave.tensor<any of bf16>) -> (!wave.tensor<any of f32>, !wave.tensor<any of bf16>)
+  return %iter_result#0, %iter_result#1 : !wave.tensor<any of f32>, !wave.tensor<any of bf16>
+}
+
+// CHECK-LABEL: @register
+func.func @register() {
+  %0 = arith.constant 0.0 : f32
+  // CHECK: wave.register %{{.*}} : !wave.tensor<[@Y, @Z] of f32>
+  wave.register %0 : !wave.tensor<[@Y, @Z] of f32>
+  return
 }

--- a/test/lib/Transforms/TestWaveDialectConstructors.cpp
+++ b/test/lib/Transforms/TestWaveDialectConstructors.cpp
@@ -45,7 +45,9 @@ static llvm::LogicalResult testCreateTensor(mlir::Operation *op) {
   auto type = wave::WaveTensorType::getChecked(
       [&]() { return op->emitError(); }, op->getContext(),
       llvm::ArrayRef(shapeComponents), fullySpecifiedAttr.getValue(),
-      elementType);
+      elementType,
+      wave::WaveAddressSpaceAttr::get(op->getContext(),
+                                      wave::WaveAddressSpace::Unspecified));
   return llvm::failure(type == nullptr);
 }
 


### PR DESCRIPTION
Introduce a small subset of op definitions sufficient to define MoE-relevant kernels currently expressed in Python.

Introduce an address space to the tensor type and an ODS type constraint to restrict the introduced arithmetic ops to in-registers tensors and the memory access ops to the in-memory/register tensors where relevant.