### PR TITLE
Fix static build and lit test config

### DIFF
--- a/lib/Dialect/Wave/IR/CMakeLists.txt
+++ b/lib/Dialect/Wave/IR/CMakeLists.txt
@@ -11,3 +11,10 @@ add_mlir_dialect_library(MLIRWaveDialect
   MLIRIR
   MLIRControlFlowInterfaces
 )
+
+# Install the Wave dialect library so Python can find it at runtime.
+install(TARGETS MLIRWaveDialect
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -54,13 +54,20 @@ config.water_tools_dir = os.path.join(config.water_obj_root, "bin")
 config.water_libs_dir = os.path.join(config.water_obj_root, "lib")
 
 config.substitutions.append(("%water_libs", config.water_libs_dir))
-py_root_base = os.path.dirname(os.path.dirname(config.water_obj_root))  # -> .../build
-config.substitutions.append(
-    ("%py_pkg_root", os.path.join(py_root_base, "python_packages"))
-)
 
-if os.path.isdir(os.path.join(py_root_base, "python_packages", "water_mlir")):
+# Locate the Python package root:
+# 1) Prefer build-tree location produced by add_mlir_python_modules:
+#    <build>/python_packages
+# 2) Allow override to point at an install prefix via WATER_PYTHON_PACKAGE_ROOT
+py_pkg_root = os.path.join(config.water_obj_root, "python_packages")
+py_pkg_root = os.environ.get("WATER_PYTHON_PACKAGE_ROOT", py_pkg_root)
+
+config.substitutions.append(("%py_pkg_root", py_pkg_root))
+
+if os.path.isdir(os.path.join(py_pkg_root, "water_mlir")):
     config.available_features.add("water_python")
+    # Ensure spawned processes can import the package during tests
+    llvm_config.with_environment("PYTHONPATH", py_pkg_root, append_path=True)
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)


### PR DESCRIPTION
This adds an install target for python so it can find the dialects at runtime and fixes the lit config to find the correct directory of the bindings.