### PR TITLE
Add a trait for shape compatibility verification

### DIFF
--- a/include/water/Dialect/Wave/IR/WaveInterfaces.td
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.td
@@ -9,9 +9,17 @@
 
 include "mlir/IR/OpBase.td"
 
+//-----------------------------------------------------------------------------
+// Operation traits
+//-----------------------------------------------------------------------------
+
 def HasWaveIndexMapping : NativeOpTrait<"HasWaveIndexMapping"> {
     let cppNamespace = "::wave";
 }
+
+//-----------------------------------------------------------------------------
+// WaveInferTypeOpInterface and implementation traits
+//-----------------------------------------------------------------------------
 
 def WaveInferTypeOpInterface : OpInterface<"WaveInferTypeOpInterface"> {
   let description = [{
@@ -56,6 +64,20 @@ def IdentityTypeInferenceOpTrait
 }
 
 def NoOpTypeInferenceOpTrait : NativeOpTrait<"NoOpTypeInferenceOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
+//-----------------------------------------------------------------------------
+// Type verification traits
+//-----------------------------------------------------------------------------
+
+def CompatibleOperandsAndResultsOpTrait
+    : NativeOpTrait<"CompatibleOperandsAndResultsOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
+def CompatibleOperandsAndResultsIgnoreSpaceOpTrait
+    : NativeOpTrait<"CompatibleOperandsAndResultsIgnoreSpaceOpTrait"> {
   let cppNamespace = "::wave";
 }
 

--- a/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/include/water/Dialect/Wave/IR/WaveOps.td
@@ -47,7 +47,8 @@ class WaveArithmeticOpDoc {
 
 class UnaryWaveOp<string mnemonic>
     : WaveOp<mnemonic,
-         [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait]>,
+         [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait,
+          CompatibleOperandsAndResultsOpTrait]>,
       WaveArithmeticOpDoc {
   let arguments = !con((ins
     Arg<WaveTensorInRegister, "Argument">:$argument
@@ -63,7 +64,8 @@ class UnaryWaveOp<string mnemonic>
 
 class BinaryWaveOp<string mnemonic>
     : WaveOp<mnemonic,
-         [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait]>,
+         [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait,
+          CompatibleOperandsAndResultsOpTrait]>,
       WaveArithmeticOpDoc {
   let arguments = !con((ins
     Arg<WaveTensorInRegister, "Left-hand side">:$lhs,
@@ -188,7 +190,8 @@ def YieldOp : Op<WaveDialect, "yield",
 //-----------------------------------------------------------------------------
 
 def ReadOp : WaveOp<"read", [
-    WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait]> {
+    WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait,
+    CompatibleOperandsAndResultsIgnoreSpaceOpTrait]> {
   let summary = "Reads from memory";
   let description = [{
     Moves data from a memory-resident tensor to a register-resident tensor
@@ -232,7 +235,8 @@ def RegisterOp : WaveOp<"register", [
 }
 
 def WriteOp : WaveOp<"write", [
-    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait]> {
+    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait,
+    CompatibleOperandsAndResultsIgnoreSpaceOpTrait]> {
   let summary = "Writes into memory";
   let description = [{
     Moves data from a register-resident tensor into a memory-resident tensor

--- a/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -5,11 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "water/Dialect/Wave/IR/WaveInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveAttrs.h"
+#include "water/Dialect/Wave/IR/WaveTypes.h"
+
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
-#include "water/Dialect/Wave/IR/WaveAttrs.h"
-#include "water/Dialect/Wave/IR/WaveTypes.h"
+#include "llvm/ADT/SmallString.h"
 
 using namespace mlir;
 
@@ -108,6 +110,10 @@ void wave::printWaveIndexDict(OpAsmPrinter &printer, Operation *op,
   printer.getStream() << "}";
 }
 
+//-----------------------------------------------------------------------------
+// WaveInferTypeOpInterface helpers
+//-----------------------------------------------------------------------------
+
 // Return `true` if two tensor types have the same shape. Null types are
 // considered to have different shapes.
 static bool hasSameShape(wave::WaveTensorType lhs, wave::WaveTensorType rhs) {
@@ -175,6 +181,172 @@ wave::detail::identityTypeInferencePropagate(
     changeResult |= *res;
   }
   return changeResult;
+}
+
+//-----------------------------------------------------------------------------
+// Verification helpers
+//-----------------------------------------------------------------------------
+
+// Update negative indices in the array to positive equivalents given the total
+// rank, e.g. -1 and -3 get updated to 3 and 1, respectively, for the rank of 4.
+static void updateNegativeIndices(llvm::MutableArrayRef<int> indices,
+                                  int rank) {
+  for (int &index : indices) {
+    if (index < 0)
+      index += rank;
+  }
+}
+
+llvm::LogicalResult wave::detail::verifyTypesMatchingDimensions(
+    std::optional<mlir::Location> loc, llvm::StringRef lhsName,
+    wave::WaveTensorType lhs, llvm::ArrayRef<int> lhsDims,
+    llvm::StringRef rhsName, wave::WaveTensorType rhs,
+    llvm::ArrayRef<int> rhsDims) {
+  assert(lhsDims.size() == rhsDims.size() &&
+         "expected lhs and rhs dim lists to be co-indexed");
+
+  // Under-specified types are okay everywhere.
+  if (!lhs.getFullySpecified() || !rhs.getFullySpecified())
+    return mlir::success();
+
+  llvm::SmallVector<int> lhsDimsVec(lhsDims), rhsDimsVec(rhsDims);
+  updateNegativeIndices(lhsDimsVec, lhs.getRank());
+  updateNegativeIndices(rhsDimsVec, rhs.getRank());
+  for (auto &&[lhsDim, rhsDim] : llvm::zip_equal(lhsDimsVec, rhsDimsVec)) {
+    wave::WaveSymbolAttr lhsExpr = lhs.getShape()[lhsDim];
+    wave::WaveSymbolAttr rhsExpr = rhs.getShape()[rhsDim];
+    if (lhsExpr == rhsExpr)
+      continue;
+
+    if (loc) {
+      mlir::emitError(*loc)
+          << "expected " << lhsName << " dimension #" << lhsDim << " ("
+          << lhsExpr << ") to match " << rhsName << " dimension #" << rhsDim
+          << " (" << rhsExpr << ")";
+    }
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+
+llvm::LogicalResult wave::detail::verifyElementTypesMatch(
+    std::optional<mlir::Location> loc, llvm::StringRef lhsName,
+    wave::WaveTensorType lhs, llvm::StringRef rhsName,
+    wave::WaveTensorType rhs) {
+  if (lhs.getElementType() == rhs.getElementType())
+    return mlir::success();
+
+  if (loc) {
+    mlir::emitError(*loc) << "expected " << lhsName << " and " << rhsName
+                          << " elemental types to match, got "
+                          << lhs.getElementType() << ", "
+                          << rhs.getElementType();
+  }
+  return mlir::failure();
+}
+
+llvm::LogicalResult wave::detail::verifyTypesCompatible(
+    wave::WaveTensorType lhs, wave::WaveTensorType rhs,
+    bool includeAddressSpace, std::optional<mlir::Location> errorLocation,
+    llvm::StringRef lhsName, llvm::StringRef rhsName) {
+  // Fast and cheap path.
+  if (lhs == rhs)
+    return mlir::success();
+
+  if (errorLocation) {
+    assert(!lhsName.empty() && !rhsName.empty() &&
+           "expected names when location is provided");
+  }
+
+  if (includeAddressSpace) {
+    if (lhs.getAddressSpaceValue() != rhs.getAddressSpaceValue() &&
+        lhs.getAddressSpaceValue() != wave::WaveAddressSpace::Unspecified &&
+        rhs.getAddressSpaceValue() != wave::WaveAddressSpace::Unspecified) {
+      if (errorLocation) {
+        emitError(*errorLocation) << "address space mismatch between" << lhsName
+                                  << " and " << rhsName;
+      }
+      return mlir::failure();
+    }
+  }
+
+  if (mlir::failed(
+          verifyElementTypesMatch(errorLocation, lhsName, lhs, rhsName, rhs)))
+    return mlir::failure();
+
+  if (!lhs.getFullySpecified() || !rhs.getFullySpecified())
+    return mlir::success();
+
+  if (lhs.getRank() != rhs.getRank()) {
+    if (errorLocation) {
+      emitError(*errorLocation)
+          << "rank mismatch between " << lhsName << " and " << rhsName;
+    }
+    return mlir::failure();
+  }
+
+  auto allDims = llvm::to_vector(llvm::iota_range<int>(0, lhs.getRank(),
+                                                       /*Inclusive=*/false));
+  return verifyTypesMatchingDimensions(errorLocation, lhsName, lhs, allDims,
+                                       rhsName, rhs, allDims);
+}
+
+static llvm::LogicalResult
+verifyTypeRange(mlir::Location loc, mlir::TypeRange range,
+                wave::WaveTensorType referenceType, bool includeAddressSpace,
+                llvm::StringRef rangeDescriptionPrefix,
+                llvm::StringRef referenceDescription) {
+  llvm::SmallString<16> rangeDescription(rangeDescriptionPrefix);
+  for (auto &&[i, type] : llvm::enumerate(range)) {
+    auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(type);
+    if (!tensorType)
+      continue;
+
+    rangeDescription.resize(rangeDescriptionPrefix.size());
+    llvm::raw_svector_ostream os(rangeDescription);
+    os << i;
+
+    if (mlir::failed(wave::detail::verifyTypesCompatible(
+            tensorType, referenceType, includeAddressSpace, loc, os.str(),
+            referenceDescription))) {
+      return llvm::failure();
+    }
+  }
+  return llvm::success();
+}
+
+llvm::LogicalResult wave::detail::verifyCompatibleOperandsAndResultsOpTrait(
+    mlir::Operation *op, bool includeAddressSpace) {
+  const llvm::StringLiteral kOperandNamePrefix = "operand #";
+  const llvm::StringLiteral kResultNamePrefix = "result #";
+  std::string referenceDescription;
+  llvm::raw_string_ostream os(referenceDescription);
+  wave::WaveTensorType referenceType;
+  auto it =
+      llvm::find_if(op->getOperandTypes(), llvm::IsaPred<wave::WaveTensorType>);
+  if (it != op->getOperandTypes().end()) {
+    referenceType = llvm::cast<wave::WaveTensorType>(*it);
+    os << kOperandNamePrefix
+       << std::distance(op->getOperandTypes().begin(), it);
+  } else {
+    auto it2 = llvm::find_if(op->getResultTypes(),
+                             llvm::IsaPred<wave::WaveTensorType>);
+    // No tensor-typed operands or results, nothing to verify.
+    if (it2 == op->getResultTypes().end())
+      return llvm::success();
+
+    referenceType = llvm::cast<wave::WaveTensorType>(*it2);
+    os << kResultNamePrefix << std::distance(op->getResultTypes().begin(), it2);
+  }
+  assert(referenceType);
+
+  if (llvm::failed(verifyTypeRange(op->getLoc(), op->getOperandTypes(),
+                                   referenceType, includeAddressSpace,
+                                   kOperandNamePrefix, os.str())))
+    return llvm::failure();
+
+  return verifyTypeRange(op->getLoc(), op->getResultTypes(), referenceType,
+                         includeAddressSpace, kResultNamePrefix, os.str());
 }
 
 #include "water/Dialect/Wave/IR/WaveOpInterfaces.cpp.inc"

--- a/test/Dialect/Wave/ops-invalid.mlir
+++ b/test/Dialect/Wave/ops-invalid.mlir
@@ -108,3 +108,33 @@ func.func @index_attr_not_dict(%arg0: f32) {
   "wave.register"(%arg0) { index = 42 } : (f32) -> !wave.tensor<[@M] of f32, <register>>
   return
 }
+
+// -----
+
+func.func @mismatch_shape_binary(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of f32>) {
+  // expected-error @below {{expected operand #1 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
+  wave.add %lhs, %rhs : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>) -> !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @mismatch_shape_unary(%lhs: !wave.tensor<[@A, @B] of f32>) {
+  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
+  wave.exp2 %lhs : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@B, @C] of f32>
+  return
+}
+
+// -----
+
+func.func @mismatch_shape_read(%lhs: !wave.tensor<[@A, @B] of f32, <global>>) {
+  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
+  wave.read %lhs : (!wave.tensor<[@A, @B] of f32, <global>>) -> !wave.tensor<[@B, @C] of f32, <register>>
+  return
+}
+
+// -----
+
+func.func @mismatch_shape_write(%lhs: !wave.tensor<[@A, @B] of f32, <register>>, %rhs: !wave.tensor<[@B, @C] of f32, <global>>) {
+  // expected-error @below {{expected operand #1 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
+  wave.write %lhs, %rhs : !wave.tensor<[@A, @B] of f32, <register>>, !wave.tensor<[@B, @C] of f32, <global>>
+}


### PR DESCRIPTION
This is similar to upstream SameOperandsAndResults trait but allows for weaker shape compatibility checks rather than fully type equality checks. We need this so we can support yet-uninferred types and unspecified address spaces.