### PR TITLE
Introduce normal forms

### DIFF
--- a/include/water/Dialect/Wave/IR/WaveAttrs.h
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.h
@@ -14,4 +14,13 @@
 #define GET_ATTRDEF_CLASSES
 #include "water/Dialect/Wave/IR/WaveAttrs.h.inc"
 
+namespace wave::detail {
+/// Verifies that the provided operation and its descendants satisfies the
+/// required normal forms. Emits diagnostics if requested, otherwise just
+/// returns failure.
+llvm::LogicalResult verifyNormalFormAttr(mlir::Operation *root,
+                                         wave::WaveNormalForm form,
+                                         bool emitDiagnostics);
+} // namespace wave::detail
+
 #endif // WATER_DIALECT_WAVE_IR_WAVEATTRS_H

--- a/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -30,6 +30,7 @@ def WaveAddressSpaceAttr
     : EnumAttr<WaveDialect, WaveAddressSpaceEnum, "address_space"> {
   let assemblyFormat = "`<` $value `>`";
 }
+
 //-----------------------------------------------------------------------------
 // MMA kind enum and attribute
 //-----------------------------------------------------------------------------
@@ -67,6 +68,43 @@ def WaveMmaKindEnum
 }
 
 def WaveMmaKindAttr : EnumAttr<WaveDialect, WaveMmaKindEnum, "mma_kind"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+//-----------------------------------------------------------------------------
+// Normal form enum and attribute
+//-----------------------------------------------------------------------------
+
+def NORMAL_FORM_FUNC_BOUNDARY : I32BitEnumAttrCaseBit<
+    "FunctionBoundarySpecified", 0, "full_func_boundary">;
+def NORMAL_FORM_OP_TYPES : I32BitEnumAttrCaseBit<
+    "OpTypesSpecified",          1, "full_op_types">;
+def NORMAL_FORM_INDEX_EXPRS : I32BitEnumAttrCaseBit<
+    "IndexExprsSpecified",       2, "index_exprs">;
+
+def NORMAL_FORM_FULL_TYPES : I32BitEnumAttrCaseGroup<
+    "AllTypesSpecified", [
+        NORMAL_FORM_FUNC_BOUNDARY, NORMAL_FORM_OP_TYPES
+    ], "full_types">;
+
+def WaveNormalFormEnum : I32BitEnumAttr<"WaveNormalForm", "", [
+  I32BitEnumAttrCaseNone<"None", "none">,
+  // Bits.
+  NORMAL_FORM_FUNC_BOUNDARY,
+  NORMAL_FORM_OP_TYPES,
+  NORMAL_FORM_INDEX_EXPRS,
+
+  // Group aliases.
+  NORMAL_FORM_FULL_TYPES
+]> {
+  let cppNamespace = "::wave";
+  let separator = ",";
+  let genSpecializedAttr = 0;
+  let printBitEnumPrimaryGroups = 1;
+}
+
+def WaveNormalFormAttr
+    : EnumAttr<WaveDialect, WaveNormalFormEnum, "normal_form"> {
   let assemblyFormat = "`<` $value `>`";
 }
 

--- a/include/water/Dialect/Wave/IR/WaveDialect.td
+++ b/include/water/Dialect/Wave/IR/WaveDialect.td
@@ -17,7 +17,7 @@ def WaveDialect : Dialect {
     Passes on the Wave dialect follow the concept of normal forms. A module
     containing Wave dialect operations may satisfy conditions of several normal
     forms defined by the `WaveNormalFormAttr`. When this is the case, the module
-    (or some its ancestor), is expected to have the corresponding attribute
+    (or one of its ancestors), is expected to have the corresponding attribute
     attached. The attribute enforces normal form invariants in its verifiers.
     Passes can then check whether the attribute is present as a precondition for
     them to run, i.e., only apply to IR in certain normal forms. Passes may also

--- a/include/water/Dialect/Wave/IR/WaveDialect.td
+++ b/include/water/Dialect/Wave/IR/WaveDialect.td
@@ -13,13 +13,37 @@ def WaveDialect : Dialect {
   let name = "wave";
   let summary = "Dialect for Wave DSL operations and types";
 
+  let description = [{
+    Passes on the Wave dialect follow the concept of normal forms. A module
+    containing Wave dialect operations may satisfy conditions of several normal
+    forms defined by the `WaveNormalFormAttr`. When this is the case, the module
+    (or some its ancestor), is expected to have the corresponding attribute
+    attached. The attribute enforces normal form invariants in its verifiers.
+    Passes can then check whether the attribute is present as a precondition for
+    them to run, i.e., only apply to IR in certain normal forms. Passes may also
+    update the attribute to reflect new normal forms after they complete, which
+    the following passes may rely on. For example, the type inference pass may
+    set the attribute indicating that all types are fully inferred, which is
+    a precondition for the lowering pass to run.
+  }];
+
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 
+  let hasOperationAttrVerify = 1;
+
   let extraClassDeclaration = [{
     // The name of a hyperparameter attribute.
-    static constexpr llvm::StringRef kHyperparameterAttrName =
+    const static constexpr ::llvm::StringLiteral kHyperparameterAttrName =
         "wave.hyperparameters";
+
+    // The name of the normal form attribute.
+    const static constexpr ::llvm::StringLiteral kNormalFormAttrName =
+        "wave.normal_form";
+
+    // The name of the inherent attribute for op index expressions;
+    const static constexpr ::llvm::StringLiteral kIndexExprAttrName = "index";
+
     // Registration functions. The bodies of these must be placed in the file
     // containing private implementations of attributes and types, respectively.
     void registerAttributes();

--- a/include/water/Dialect/Wave/Transforms/Utils.h
+++ b/include/water/Dialect/Wave/Transforms/Utils.h
@@ -1,0 +1,27 @@
+// Copyright 2025 The Water Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "water/Dialect/Wave/IR/WaveAttrs.h"
+
+namespace wave {
+
+// Sets the attribute indicating that the operation satisfies provided normal
+// forms. The presence of the attribute, in turn, performs verification of the
+// normal form every time a verifier runs on the operation, including by default
+// after every pass.
+llvm::LogicalResult setNormalFormPassPostcondition(wave::WaveNormalForm form,
+                                                   mlir::Operation *root);
+
+// Verifies if the operation, typically the root operation about to be processed
+// by a pass, satisfies the required normal form by checking the presence of the
+// attribute that enforces verification. Emits diagnostics and returns failures
+// when it is not the case. Does *NOT* actually run verification, this is
+// automated by the presence of the attribute.
+llvm::LogicalResult verifyNormalFormPassPrecondition(wave::WaveNormalForm form,
+                                                     mlir::Operation *root,
+                                                     llvm::StringRef passName);
+
+} // namespace wave

--- a/lib/Dialect/Wave/IR/CMakeLists.txt
+++ b/lib/Dialect/Wave/IR/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRWaveDialect
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRControlFlowInterfaces
+  MLIRFunctionInterfaces
 )
 
 # Install the Wave dialect library so Python can find it at runtime.

--- a/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -170,13 +170,12 @@ void wave::WaveDialect::registerAttributes() {
       >();
 }
 
-// Verify that all types in the range satisfy the required normal forms. Emit a
+// Verify that wave tensor types in the given range are fully specified. Emit a
 // diagnostic with the given message at the location provided, if present,
 // otherwise just return failure.
 static llvm::LogicalResult
-verifyNormalFormTypeRange(std::optional<mlir::Location> loc,
-                          mlir::TypeRange types, wave::WaveNormalForm form,
-                          llvm::StringRef message) {
+verifyTypesFullySpecified(std::optional<mlir::Location> loc,
+                          mlir::TypeRange types, llvm::StringRef message) {
   for (mlir::Type type : types) {
     auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(type);
     if (!tensorType || tensorType.getFullySpecified())
@@ -209,11 +208,11 @@ llvm::LogicalResult wave::detail::verifyNormalFormAttr(
             const llvm::StringLiteral kMessage =
                 "normal form requires tensor types to be fully specified at "
                 "function boundaries";
-            if (llvm::failed(verifyNormalFormTypeRange(
-                    optionalLoc, func.getArgumentTypes(), form, kMessage)))
+            if (llvm::failed(verifyTypesFullySpecified(
+                    optionalLoc, func.getArgumentTypes(), kMessage)))
               return mlir::WalkResult::interrupt();
-            if (llvm::failed(verifyNormalFormTypeRange(
-                    optionalLoc, func->getResultTypes(), form, kMessage)))
+            if (llvm::failed(verifyTypesFullySpecified(
+                    optionalLoc, func->getResultTypes(), kMessage)))
               return mlir::WalkResult::interrupt();
           }
         }
@@ -222,16 +221,16 @@ llvm::LogicalResult wave::detail::verifyNormalFormAttr(
                                      wave::WaveNormalForm::OpTypesSpecified)) {
           const llvm::StringLiteral kMessage =
               "normal form requires tensor types to be fully specified";
-          if (llvm::failed(verifyNormalFormTypeRange(
-                  optionalLoc, op->getOperandTypes(), form, kMessage)))
+          if (llvm::failed(verifyTypesFullySpecified(
+                  optionalLoc, op->getOperandTypes(), kMessage)))
             return mlir::WalkResult::interrupt();
-          if (llvm::failed(verifyNormalFormTypeRange(
-                  optionalLoc, op->getResultTypes(), form, kMessage)))
+          if (llvm::failed(verifyTypesFullySpecified(
+                  optionalLoc, op->getResultTypes(), kMessage)))
             return mlir::WalkResult::interrupt();
           for (mlir::Region &region : op->getRegions()) {
             for (mlir::Block &block : region) {
-              if (llvm::failed(verifyNormalFormTypeRange(
-                      optionalLoc, block.getArgumentTypes(), form, kMessage)))
+              if (llvm::failed(verifyTypesFullySpecified(
+                      optionalLoc, block.getArgumentTypes(), kMessage)))
                 return mlir::WalkResult::interrupt();
             }
           }

--- a/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -6,11 +6,15 @@
 
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
 #include "water/Dialect/Wave/IR/WaveDialect.h"
+#include "water/Dialect/Wave/IR/WaveInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveTypes.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -164,4 +168,88 @@ void wave::WaveDialect::registerAttributes() {
 #define GET_ATTRDEF_LIST
 #include "water/Dialect/Wave/IR/WaveAttrs.cpp.inc"
       >();
+}
+
+// Verify that all types in the range satisfy the required normal forms. Emit a
+// diagnostic with the given message at the location provided, if present,
+// otherwise just return failure.
+static llvm::LogicalResult
+verifyNormalFormTypeRange(std::optional<mlir::Location> loc,
+                          mlir::TypeRange types, wave::WaveNormalForm form,
+                          llvm::StringRef message) {
+  for (mlir::Type type : types) {
+    auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(type);
+    if (!tensorType || tensorType.getFullySpecified())
+      continue;
+
+    if (loc)
+      mlir::emitError(*loc) << message;
+    return llvm::failure();
+  }
+  return llvm::success();
+}
+
+llvm::LogicalResult wave::detail::verifyNormalFormAttr(
+    mlir::Operation *root, wave::WaveNormalForm form, bool emitDiagnostics) {
+  // No normal form required.
+  if (form == wave::WaveNormalForm::None)
+    return llvm::success();
+
+  // Walk in pre-order so we hit functions sooner and verify them for the first
+  // form.
+  mlir::WalkResult walkResult =
+      root->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+        std::optional<mlir::Location> optionalLoc;
+        if (emitDiagnostics)
+          optionalLoc = op->getLoc();
+
+        if (auto func = llvm::dyn_cast<mlir::FunctionOpInterface>(op)) {
+          if (wave::bitEnumContainsAll(
+                  form, wave::WaveNormalForm::FunctionBoundarySpecified)) {
+            const llvm::StringLiteral kMessage =
+                "normal form requires tensor types to be fully specified at "
+                "function boundaries";
+            if (llvm::failed(verifyNormalFormTypeRange(
+                    optionalLoc, func.getArgumentTypes(), form, kMessage)))
+              return mlir::WalkResult::interrupt();
+            if (llvm::failed(verifyNormalFormTypeRange(
+                    optionalLoc, func->getResultTypes(), form, kMessage)))
+              return mlir::WalkResult::interrupt();
+          }
+        }
+
+        if (wave::bitEnumContainsAll(form,
+                                     wave::WaveNormalForm::OpTypesSpecified)) {
+          const llvm::StringLiteral kMessage =
+              "normal form requires tensor types to be fully specified";
+          if (llvm::failed(verifyNormalFormTypeRange(
+                  optionalLoc, op->getOperandTypes(), form, kMessage)))
+            return mlir::WalkResult::interrupt();
+          if (llvm::failed(verifyNormalFormTypeRange(
+                  optionalLoc, op->getResultTypes(), form, kMessage)))
+            return mlir::WalkResult::interrupt();
+          for (mlir::Region &region : op->getRegions()) {
+            for (mlir::Block &block : region) {
+              if (llvm::failed(verifyNormalFormTypeRange(
+                      optionalLoc, block.getArgumentTypes(), form, kMessage)))
+                return mlir::WalkResult::interrupt();
+            }
+          }
+        }
+
+        if (wave::bitEnumContainsAll(
+                form, wave::WaveNormalForm::IndexExprsSpecified)) {
+          if (op->hasTrait<wave::HasWaveIndexMapping>() &&
+              !op->getAttr(wave::WaveDialect::kIndexExprAttrName)) {
+            op->emitError()
+                << "normal form requires index expressions to be "
+                   "provided for all supported wave dialect operations";
+            return mlir::WalkResult::interrupt();
+          }
+        }
+
+        return mlir::WalkResult::advance();
+      });
+
+  return llvm::failure(walkResult.wasInterrupted());
 }

--- a/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -21,3 +21,23 @@ void wave::WaveDialect::initialize() {
       >();
   registerTypes();
 }
+
+llvm::LogicalResult
+wave::WaveDialect::verifyOperationAttribute(mlir::Operation *op,
+                                            mlir::NamedAttribute attr) {
+  if (attr.getName() == kNormalFormAttrName) {
+    if (auto enumAttr = llvm::dyn_cast<WaveNormalFormAttr>(attr.getValue())) {
+      return detail::verifyNormalFormAttr(op, enumAttr.getValue(),
+                                          /*emitDiagnostics=*/true);
+    }
+    return op->emitError() << attr.getName() << " expects a WaveNormalFormAttr";
+  }
+  if (attr.getName() == kHyperparameterAttrName) {
+    if (llvm::isa<wave::WaveHyperparameterAttr>(attr.getValue()))
+      return llvm::success();
+    return op->emitError() << attr.getName()
+                           << " expects a WaveHyperparameterAttr";
+  }
+  return op->emitError() << "unexpected wave dialect attribute "
+                         << attr.getName() << " = " << attr.getValue();
+}

--- a/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -6,6 +6,7 @@
 
 #include "water/Dialect/Wave/IR/WaveInterfaces.h"
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
+#include "water/Dialect/Wave/IR/WaveDialect.h"
 #include "water/Dialect/Wave/IR/WaveTypes.h"
 
 #include "mlir/IR/AffineMap.h"
@@ -16,12 +17,12 @@
 using namespace mlir;
 
 LogicalResult wave::verifyWaveIndexMappings(Operation *op) {
-  auto dict = op->getAttrDictionary();
-  auto indexNamed = dict.getNamed("index");
-  if (!indexNamed)
+  // The attribute is optional.
+  Attribute attribute = op->getAttr(wave::WaveDialect::kIndexExprAttrName);
+  if (!attribute)
     return success();
 
-  auto dictAttr = dyn_cast<DictionaryAttr>(indexNamed->getValue());
+  auto dictAttr = dyn_cast<DictionaryAttr>(attribute);
   if (!dictAttr)
     return op->emitError("'index' attribute must be a dictionary");
 

--- a/lib/Dialect/Wave/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Wave/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRWaveTransforms
   LowerRegister.cpp
   LowerWaveToMLIR.cpp
   TypeConverter.cpp
+  Utils.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/water/

--- a/lib/Dialect/Wave/Transforms/Utils.cpp
+++ b/lib/Dialect/Wave/Transforms/Utils.cpp
@@ -1,0 +1,40 @@
+// Copyright 2025 The Water Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "water/Dialect/Wave/Transforms/Utils.h"
+#include "water/Dialect/Wave/IR/WaveDialect.h"
+
+#include "mlir/IR/Operation.h"
+
+llvm::LogicalResult
+wave::setNormalFormPassPostcondition(wave::WaveNormalForm form,
+                                     mlir::Operation *root) {
+  llvm::LogicalResult result =
+      wave::detail::verifyNormalFormAttr(root, form, /*emitDiagnostics=*/false);
+  if (llvm::succeeded(result))
+    root->setAttr(wave::WaveDialect::kNormalFormAttrName,
+                  wave::WaveNormalFormAttr::get(root->getContext(), form));
+  return result;
+}
+
+llvm::LogicalResult
+wave::verifyNormalFormPassPrecondition(wave::WaveNormalForm form,
+                                       mlir::Operation *root,
+                                       llvm::StringRef passName) {
+
+  for (mlir::Operation *op = root; op != nullptr; op = op->getParentOp()) {
+    auto attr = op->getAttrOfType<wave::WaveNormalFormAttr>(
+        wave::WaveDialect::kNormalFormAttrName);
+    if (!attr)
+      continue;
+    if (wave::bitEnumContainsAll(attr.getValue(), form))
+      return llvm::success();
+  }
+  return root->emitError()
+         << passName
+         << " pass expects the root operation or its ancestor to guarantee the "
+         << wave::stringifyEnum(form) << " normal form";
+}

--- a/test/Dialect/Wave/attr-type-invalid.mlir
+++ b/test/Dialect/Wave/attr-type-invalid.mlir
@@ -7,3 +7,13 @@ func.func private @unspecified_tensor() -> !wave.tensor<any of !wave.tensor<any 
 
 // expected-error @below {{shape not expected for non-fully specified tensors}}
 "wave_test.create_tensor"() {fully_specified = false, shape = [@A, @B]} : () -> ()
+
+// -----
+
+// expected-error @below {{"wave.hyperparameters" expects a WaveHyperparameterAttr}}
+module attributes {wave.hyperparameters = 1} {}
+
+// -----
+
+// expected-error @below {{unexpected wave dialect attribute "wave.unexpected"}}
+module attributes {wave.unexpected = 42} {}

--- a/test/Dialect/Wave/infer-types-force.mlir
+++ b/test/Dialect/Wave/infer-types-force.mlir
@@ -1,18 +1,20 @@
 // RUN: water-opt %s --water-wave-infer-types='force=1' --split-input-file --verify-diagnostics
 
-// expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
-func.func @iterate_conflict(%arg0: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{type conflict was detected for result #0}}
-  %0 = wave.iterate @I iter_args(%arg0) {
+module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
   // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
-  ^bb0(%arg1: !wave.tensor<[@A] of f32>):
-    wave.yield %arg1 : !wave.tensor<[@A] of f32>
-  } : (!wave.tensor<[@A] of f32>) -> (!wave.tensor<any of f32>)
-  // expected-error @below {{type conflict was detected for result #0}}
-  wave.iterate @I iter_args(%0) {
-  // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
-  ^bb0(%arg1: !wave.tensor<any of f32>):
-    wave.yield %arg1 : !wave.tensor<any of f32>
-  } : (!wave.tensor<any of f32>) -> (!wave.tensor<[@B] of f32>)
-  return
+  func.func @iterate_conflict(%arg0: !wave.tensor<[@A] of f32>) {
+    // expected-error @below {{type conflict was detected for result #0}}
+    %0 = wave.iterate @I iter_args(%arg0) {
+    // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
+    ^bb0(%arg1: !wave.tensor<[@A] of f32>):
+      wave.yield %arg1 : !wave.tensor<[@A] of f32>
+    } : (!wave.tensor<[@A] of f32>) -> (!wave.tensor<any of f32>)
+    // expected-error @below {{type conflict was detected for result #0}}
+    wave.iterate @I iter_args(%0) {
+    // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
+    ^bb0(%arg1: !wave.tensor<any of f32>):
+      wave.yield %arg1 : !wave.tensor<any of f32>
+    } : (!wave.tensor<any of f32>) -> (!wave.tensor<[@B] of f32>)
+    return
+  }
 }

--- a/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -1,129 +1,141 @@
 // RUN: water-opt %s -allow-unregistered-dialect -lower-wave-to-mlir -split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @lower_register
-func.func @lower_register() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
-  // CHECK-NOT: wave.register
-  // CHECK:     arith.constant dense<0.000000e+00> : vector<10x1xf32>
-  %cst = arith.constant 0.0 : f32
-  wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
-
-  // CHECK:     arith.constant dense<1.000000e+00> : vector<10x1x100xf32>
-  %cst1 = arith.constant 1.0 : f32
-  wave.register %cst1 : !wave.tensor<[@Y, @Z, @X] of f32, <register>>
-
-  // CHECK:     arith.constant dense<2> : vector<10x1x100xi32>
-  %cst2 = arith.constant 2 : i32
-  wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  return
-}
-
-// -----
-
-// CHECK-LABEL: func.func @lower_register_with_unrealized_cast
-func.func @lower_register_with_unrealized_cast() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
-  // CHECK-NOT: wave.register
-  // CHECK:     %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<10x1xf32>
-  // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[CST]] : vector<10x1xf32> to !wave.tensor<[@Y, @Z] of f32, <register>>
-  // CHECK:     "test.foo"(%[[CAST]])
-  %cst = arith.constant 0.0 : f32
-  %0 = wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
-  "test.foo"(%0) : (!wave.tensor<[@Y, @Z] of f32, <register>>) -> ()
-  return
-}
-
-// -----
-
-// CHECK-LABEL: func.func @lower_nested_register
-func.func @lower_nested_register(%cond: i1) attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
-  // CHECK-NOT: wave.register
-  scf.if %cond {
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  // CHECK-LABEL: func.func @lower_register
+  func.func @lower_register() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+    // CHECK-NOT: wave.register
     // CHECK:     arith.constant dense<0.000000e+00> : vector<10x1xf32>
     %cst = arith.constant 0.0 : f32
     wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
-    scf.yield
-  } else {
+
     // CHECK:     arith.constant dense<1.000000e+00> : vector<10x1x100xf32>
     %cst1 = arith.constant 1.0 : f32
     wave.register %cst1 : !wave.tensor<[@Y, @Z, @X] of f32, <register>>
-    scf.yield
+
+    // CHECK:     arith.constant dense<2> : vector<10x1x100xi32>
+    %cst2 = arith.constant 2 : i32
+    wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    return
   }
-  return
 }
 
 // -----
 
-// CHECK-LABEL: func.func @lower_add
-func.func @lower_add() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
-  // CHECK-NOT: wave.add
-  // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
-  // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
-  // CHECK:     arith.addf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
-  %cst = arith.constant 0.0 : f32
-  %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-  %cst1 = arith.constant 1.0 : f32
-  %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-  %addf = wave.add %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-
-  // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<10x1x100xi32>
-  // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
-  // CHECK:     arith.addi %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
-  %cst2 = arith.constant 2 : i32
-  %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  %cst3 = arith.constant 3 : i32
-  %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  %addi = wave.add %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-
-  return
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  // CHECK-LABEL: func.func @lower_register_with_unrealized_cast
+  func.func @lower_register_with_unrealized_cast() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+    // CHECK-NOT: wave.register
+    // CHECK:     %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<10x1xf32>
+    // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[CST]] : vector<10x1xf32> to !wave.tensor<[@Y, @Z] of f32, <register>>
+    // CHECK:     "test.foo"(%[[CAST]])
+    %cst = arith.constant 0.0 : f32
+    %0 = wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+    "test.foo"(%0) : (!wave.tensor<[@Y, @Z] of f32, <register>>) -> ()
+    return
+  }
 }
 
 // -----
 
-// CHECK-LABEL: func.func @lower_mul
-func.func @lower_mul() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
-  // CHECK-NOT: wave.mul
-  // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
-  // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
-  // CHECK:     arith.mulf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
-  %cst = arith.constant 0.0 : f32
-  %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-  %cst1 = arith.constant 1.0 : f32
-  %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-  %mulf = wave.mul %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-
-  // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<10x1x100xi32>
-  // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
-  // CHECK:     arith.muli %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
-  %cst2 = arith.constant 2 : i32
-  %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  %cst3 = arith.constant 3 : i32
-  %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  %muli = wave.mul %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-
-  return
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  // CHECK-LABEL: func.func @lower_nested_register
+  func.func @lower_nested_register(%cond: i1) attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+    // CHECK-NOT: wave.register
+    scf.if %cond {
+      // CHECK:     arith.constant dense<0.000000e+00> : vector<10x1xf32>
+      %cst = arith.constant 0.0 : f32
+      wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+      scf.yield
+    } else {
+      // CHECK:     arith.constant dense<1.000000e+00> : vector<10x1x100xf32>
+      %cst1 = arith.constant 1.0 : f32
+      wave.register %cst1 : !wave.tensor<[@Y, @Z, @X] of f32, <register>>
+      scf.yield
+    }
+    return
+  }
 }
 
 // -----
 
-// CHECK-LABEL: func.func @lower_div
-func.func @lower_div() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
-  // CHECK-NOT: wave.div
-  // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
-  // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
-  // CHECK:     arith.divf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
-  %cst = arith.constant 0.0 : f32
-  %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-  %cst1 = arith.constant 1.0 : f32
-  %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-  %divf = wave.div %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  // CHECK-LABEL: func.func @lower_add
+  func.func @lower_add() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+    // CHECK-NOT: wave.add
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
+    // CHECK:     arith.addf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
+    %cst = arith.constant 0.0 : f32
+    %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %cst1 = arith.constant 1.0 : f32
+    %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %addf = wave.add %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
 
-  // CHECK:     %[[LHSI:.*]] = arith.constant dense<-2> : vector<10x1x100xi32>
-  // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
-  // CHECK:     arith.divsi %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
-  %cst2 = arith.constant -2 : i32
-  %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  %cst3 = arith.constant 3 : i32
-  %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-  %divsi = wave.div %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<10x1x100xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
+    // CHECK:     arith.addi %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
+    %cst2 = arith.constant 2 : i32
+    %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %cst3 = arith.constant 3 : i32
+    %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %addi = wave.add %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
 
-  return
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  // CHECK-LABEL: func.func @lower_mul
+  func.func @lower_mul() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+    // CHECK-NOT: wave.mul
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
+    // CHECK:     arith.mulf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
+    %cst = arith.constant 0.0 : f32
+    %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %cst1 = arith.constant 1.0 : f32
+    %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %mulf = wave.mul %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<10x1x100xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
+    // CHECK:     arith.muli %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
+    %cst2 = arith.constant 2 : i32
+    %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %cst3 = arith.constant 3 : i32
+    %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %muli = wave.mul %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  // CHECK-LABEL: func.func @lower_div
+  func.func @lower_div() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+    // CHECK-NOT: wave.div
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
+    // CHECK:     arith.divf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
+    %cst = arith.constant 0.0 : f32
+    %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %cst1 = arith.constant 1.0 : f32
+    %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %divf = wave.div %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<-2> : vector<10x1x100xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
+    // CHECK:     arith.divsi %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
+    %cst2 = arith.constant -2 : i32
+    %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %cst3 = arith.constant 3 : i32
+    %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %divsi = wave.div %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+
+    return
+  }
 }

--- a/test/Dialect/Wave/normal-forms.mlir
+++ b/test/Dialect/Wave/normal-forms.mlir
@@ -1,0 +1,28 @@
+// RUN: water-opt %s --split-input-file --verify-diagnostics
+
+module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
+  // expected-error @below {{normal form requires tensor types to be fully specified at function boundaries}}
+  func.func private @foo(!wave.tensor<any of f32>)
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_op_types>} {
+  func.func @foo() {
+    %0 = arith.constant 0.0 : f32
+    // expected-error @below {{normal form requires tensor types to be fully specified}}
+    wave.register %0 : !wave.tensor<any of f32, <register>>
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<index_exprs>} {
+  func.func @bar() {
+    %0 = arith.constant 0.0 : f32
+    // expected-error @below {{normal form requires index expressions to be provided for all supported wave dialect operations}}
+    wave.register %0 : !wave.tensor<[@X] of f32, <register>>
+    return
+  }
+}


### PR DESCRIPTION
Introduce the concept of normal forms. Passes on the Wave dialect follow the concept of normal forms. A module containing Wave dialect operations may satisfy conditions of several normal forms defined by the `WaveNormalFormAttr`. When this is the case, the module (or some its ancestor), is expected to have the corresponding attribute attached. The attribute enforces normal form invariants in its verifiers.  Passes can then check whether the attribute is present as a precondition for them to run, i.e., only apply to IR in certain normal forms. Passes may also update the attribute to reflect new normal forms after they complete, which the following passes may rely on. For example, the type inference pass may set the attribute indicating that all types are fully inferred, which is a precondition for the lowering pass to run.

This allows us to represent invariants at a finer granularity in the pass pipeline than op- or dialect-level verifiers, which otherwise would require introducing new operations or dialects to express the invariants in their verifiers. This also enables passes to specify pre- and post-conditions in a way that is visible in the IR.

This can be potentially extended using interfaces, deferring self-verification to each individual opeation and providing a registration mechanism for normal forms.

This can be further combined with the transform dialect to provide "typed" passes where the type of the pass arguments and results is constructed from normal forms it expects in the input and guarantees on the output. This, in turn, would allow us to only run the normal form verifiers when the normal form annotation changes.