### PR TITLE
Make type conversion context-insensitive

### DIFF
--- a/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -38,7 +38,7 @@ wave::WaveDialect::verifyOperationAttribute(mlir::Operation *op,
              << attr.getName() << " expects a WaveHyperparameterAttr";
     }
 
-    // TODO: consider a mode where parameters can be be union'ed, but not
+    // TODO: consider a mode where parameters can be union'ed, but not
     // redefined. There are passes that currently assume a single set of
     // hyperparameters.
     for (mlir::Operation *parent = op->getParentOp(); parent != nullptr;

--- a/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -33,10 +33,25 @@ wave::WaveDialect::verifyOperationAttribute(mlir::Operation *op,
     return op->emitError() << attr.getName() << " expects a WaveNormalFormAttr";
   }
   if (attr.getName() == kHyperparameterAttrName) {
-    if (llvm::isa<wave::WaveHyperparameterAttr>(attr.getValue()))
-      return llvm::success();
-    return op->emitError() << attr.getName()
-                           << " expects a WaveHyperparameterAttr";
+    if (!llvm::isa<wave::WaveHyperparameterAttr>(attr.getValue())) {
+      return op->emitError()
+             << attr.getName() << " expects a WaveHyperparameterAttr";
+    }
+
+    // TODO: consider a mode where parameters can be be union'ed, but not
+    // redefined. There are passes that currently assume a single set of
+    // hyperparameters.
+    for (mlir::Operation *parent = op->getParentOp(); parent != nullptr;
+         parent = parent->getParentOp()) {
+      if (parent->hasAttr(kHyperparameterAttrName)) {
+        mlir::InFlightDiagnostic diag =
+            op->emitError()
+            << "defines hyperparameters when its ancestor already had";
+        diag.attachNote(parent->getLoc()) << "ancestor";
+        return diag;
+      }
+    }
+    return llvm::success();
   }
   return op->emitError() << "unexpected wave dialect attribute "
                          << attr.getName() << " = " << attr.getValue();

--- a/lib/Dialect/Wave/Transforms/LowerAllocateOp.cpp
+++ b/lib/Dialect/Wave/Transforms/LowerAllocateOp.cpp
@@ -26,16 +26,10 @@ public:
     wave::WaveTensorType resultType = op.getResult().getType();
     wave::DistributedShapeAttr distributedShape = op.getDistributedShape();
     auto *typeConverter =
-        static_cast<const wave::WaveTensorTypeConverter *>(getTypeConverter());
-    wave::WaveHyperparameterAttr hyperParameters =
-        typeConverter->getHyperparametersAt(op.getResult());
-    if (!hyperParameters) {
-      return rewriter.notifyMatchFailure(op, "no hyperparameters present");
-    }
+        static_cast<const wave::WaveTypeConverter *>(getTypeConverter());
     Type convertedResultType = typeConverter->convertTensorFromComponents(
         distributedShape.getSymbolNames(), distributedShape.getShape(),
-        resultType.getElementType(), resultType.getAddressSpaceValue(),
-        hyperParameters);
+        resultType.getElementType(), resultType.getAddressSpaceValue());
     if (!convertedResultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to construct resulting type");
@@ -82,6 +76,6 @@ public:
 } // namespace
 
 void wave::populateWaveAllocateOpLoweringPatterns(
-    WaveTensorTypeConverter &typeConverter, RewritePatternSet &patterns) {
+    WaveTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<AllocateOpLoweringPattern>(typeConverter, patterns.getContext());
 }

--- a/lib/Dialect/Wave/Transforms/LowerBinaryOps.cpp
+++ b/lib/Dialect/Wave/Transforms/LowerBinaryOps.cpp
@@ -54,7 +54,7 @@ public:
 } // namespace
 
 void wave::populateWaveBinaryOpLoweringPatterns(
-    WaveTensorTypeConverter &typeConverter, RewritePatternSet &patterns) {
+    WaveTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns
       .add<BinaryOpLoweringPattern<wave::AddOp, arith::AddFOp, arith::AddIOp>,
            BinaryOpLoweringPattern<wave::MulOp, arith::MulFOp, arith::MulIOp>,

--- a/lib/Dialect/Wave/Transforms/LowerRegister.cpp
+++ b/lib/Dialect/Wave/Transforms/LowerRegister.cpp
@@ -71,6 +71,6 @@ public:
 } // namespace
 
 void wave::populateWaveRegisterLoweringPatterns(
-    WaveTensorTypeConverter &typeConverter, RewritePatternSet &patterns) {
+    WaveTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<RegisterOpLoweringPattern>(typeConverter, patterns.getContext());
 }

--- a/test/Dialect/Wave/ops-invalid.mlir
+++ b/test/Dialect/Wave/ops-invalid.mlir
@@ -165,3 +165,11 @@ func.func @alloc_parent_no_offset() {
   %buf = wave.allocate in %alloc : !wave.tensor<[@M, @K] of bf16, <shared>> { distributed_shape = #wave.distributed_shape<[] -> (42)>}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
 }
+
+// -----
+
+module attributes { wave.hyperparameters = #wave.hyperparameters<{}> } {
+  // expected-error @below {{defines hyperparameters when its ancestor already had}}
+  // expected-note @above {{ancestor}}
+  module attributes { wave.hyperparameters = #wave.hyperparameters<{}> } {}
+}


### PR DESCRIPTION
Instead of looking up the hyperparameter table on every single type conversion, store the table in the type converter object. Construct a new type converter and apply patterns every on every nested operation with hyperparameters.

Disallow hyperparameter definitions on nested ops. This was already implicit by looking them up at the nearest function, but there's no need to be restricted to functions specficially.

This makes conversion faster by avoiding constant hyperparameter lookups and by allowing type conversion results to be cached by the infrastructure. This also guards us against creeping complexity in contextual converters.