### PR TITLE
Verify usage of hyperparameters

### DIFF
--- a/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -12,6 +12,8 @@
 #include "mlir/IR/Dialect.h"
 
 #include "water/Dialect/Wave/IR/WaveDialect.cpp.inc"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSet.h"
 
 void wave::WaveDialect::initialize() {
   registerAttributes();
@@ -20,6 +22,45 @@ void wave::WaveDialect::initialize() {
 #include "water/Dialect/Wave/IR/WaveOps.cpp.inc"
       >();
   registerTypes();
+}
+
+// Verify whether all types from the given range exclusively used symbols
+// defined in the hyperparameter attribute, report errors otherwise using the
+// provided callback. Collect used symbols into the given set for future checks.
+static llvm::LogicalResult verifyTypeRangeHyperparamUses(
+    wave::WaveHyperparameterAttr hyperparam, mlir::TypeRange types,
+    llvm::StringSet<> &usedSymbols,
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
+  for (auto [i, type] : llvm::enumerate(types)) {
+    auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(type);
+    if (!tensorType || !tensorType.getFullySpecified())
+      continue;
+
+    // TODO: we want symbol attrs rather than strings in hyperparam.
+    for (wave::WaveSymbolAttr symbol : tensorType.getShape()) {
+      usedSymbols.insert(symbol.getName());
+      if (hyperparam.getMapping().contains(symbol.getName()))
+        continue;
+
+      mlir::InFlightDiagnostic diag =
+          emitError() << "type #" << i << " uses symbolic value " << symbol
+                      << " not provided as a hyperparameter";
+      std::string availableSymbols =
+          llvm::join(llvm::map_range(hyperparam.getMapping(),
+                                     [](const mlir::NamedAttribute namedAttr) {
+                                       return namedAttr.getName().getValue();
+                                     }),
+                     ", ");
+      diag.attachNote() << "available symbols: " << availableSymbols;
+
+      // TODO: we will want a special value of the hyperparameter that indicates
+      // whether we want to turn the symbol into a dynamic value accepted by the
+      // generated function.
+      diag.attachNote() << "NYI support for symbol lowering";
+      return diag;
+    }
+  }
+  return llvm::success();
 }
 
 llvm::LogicalResult
@@ -33,7 +74,9 @@ wave::WaveDialect::verifyOperationAttribute(mlir::Operation *op,
     return op->emitError() << attr.getName() << " expects a WaveNormalFormAttr";
   }
   if (attr.getName() == kHyperparameterAttrName) {
-    if (!llvm::isa<wave::WaveHyperparameterAttr>(attr.getValue())) {
+    auto hyperparams =
+        llvm::dyn_cast<wave::WaveHyperparameterAttr>(attr.getValue());
+    if (!hyperparams) {
       return op->emitError()
              << attr.getName() << " expects a WaveHyperparameterAttr";
     }
@@ -51,6 +94,52 @@ wave::WaveDialect::verifyOperationAttribute(mlir::Operation *op,
         return diag;
       }
     }
+
+    llvm::StringSet<> usedSymbols;
+    mlir::WalkResult walkResult = op->walk([&](mlir::Operation *op) {
+      if (llvm::failed(verifyTypeRangeHyperparamUses(
+              hyperparams, op->getResultTypes(), usedSymbols,
+              [&]() { return op->emitOpError() << "result "; }))) {
+        return mlir::WalkResult::interrupt();
+      }
+
+      for (mlir::Region &region : op->getRegions()) {
+        // Can't use llvm::enumerate because of nested lambda capture defect.
+        unsigned blockNo = 0;
+        for (mlir::Block &block : region) {
+          if (llvm::failed(verifyTypeRangeHyperparamUses(
+                  hyperparams, block.getArgumentTypes(), usedSymbols, [&]() {
+                    return op->emitOpError()
+                           << "region #" << region.getRegionNumber()
+                           << " block #" << blockNo << " argument ";
+                  }))) {
+            return mlir::WalkResult::interrupt();
+          }
+          ++blockNo;
+        }
+      }
+
+      return mlir::WalkResult::advance();
+    });
+
+    if (walkResult.wasInterrupted())
+      return llvm::failure();
+
+    llvm::SmallVector<mlir::StringRef> unusedNames;
+    for (const mlir::NamedAttribute &namedAttr :
+         hyperparams.getMapping().getValue()) {
+      if (!usedSymbols.contains(namedAttr.getName().getValue()))
+        unusedNames.push_back(namedAttr.getName().getValue());
+    }
+    if (!unusedNames.empty()) {
+      // XXX: cannot use op->emitWarning as that triggers the op verifier
+      // leading to infinite recursion.
+      emitWarning(op->getLoc())
+          << "unused hyperparameter"
+          << (llvm::hasSingleElement(unusedNames) ? "" : "s") << ": "
+          << llvm::join(unusedNames, ", ");
+    }
+
     return llvm::success();
   }
   return op->emitError() << "unexpected wave dialect attribute "


### PR DESCRIPTION
When hyperparams are present, verify that any symbol used inside result or block argument types is defined in the list of hyperparameters. This ensures the IR can be lowered and correctly processed by passes.

We currently don't have a mechanism to find all other uses of symbols, for example those inside attributes attached to ops. We may need an interface to support that.