### PR TITLE
fix imports

### DIFF
--- a/python/water_mlir/sympy_to_affine_converter.py
+++ b/python/water_mlir/sympy_to_affine_converter.py
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import sympy
-from sympy.parsing import sympy_parser
 from water_mlir import ir
 
 
-from typing import List, Union, Optional, Tuple
+from typing import List
 from dataclasses import dataclass
 
 

--- a/test/Dialect/Wave/python_bindings.py
+++ b/test/Dialect/Wave/python_bindings.py
@@ -5,7 +5,6 @@ try:
     from water_mlir import ir
     from water_mlir.dialects import wave
     import water_mlir.ir as ir2
-    import water_mlir.dialects as dialects2
     from water_mlir.dialects import wave as wave2
 
     # Verify both import styles resolve to the same modules/symbols.


### PR DESCRIPTION
Running a stricter linter shows unused imports