### PR TITLE
Use str instead of sympy.Symbol to convert to affine map

### DIFF
--- a/python/water_mlir/sympy_to_affine_converter.py
+++ b/python/water_mlir/sympy_to_affine_converter.py
@@ -81,20 +81,20 @@ class AffineFraction:
 
 
 def _convert_expr_to_fraction(
-    sympy_expr: sympy.core.expr.Expr, symbols: List[sympy.core.symbol.Symbol]
+    sympy_expr: sympy.core.expr.Expr, symbols: List[str]
 ) -> AffineFraction:
     """Recursively convert sympy expression to AffineFraction"""
     if sympy_expr.is_Integer:
         return AffineFraction.from_integer(sympy_expr.p)
 
     elif sympy_expr.is_Symbol:
-        if sympy_expr in symbols:
-            symbol_idx = symbols.index(sympy_expr)
+        name = str(sympy_expr)
+        if name in symbols:
+            symbol_idx = symbols.index(name)
             return AffineFraction.from_affine_expr(ir.AffineExpr.get_symbol(symbol_idx))
         else:
-            available_symbols = [str(s) for s in symbols]
             raise AffineConversionError(
-                f"Unknown symbol '{sympy_expr}'. Available symbols: {available_symbols}"
+                f"Unknown symbol '{sympy_expr}'. Available symbols: {symbols}"
             )
 
     elif sympy_expr.is_Rational:
@@ -187,7 +187,7 @@ def _convert_expr_to_fraction(
 
 
 def convert_sympy_to_affine_map(
-    expr: sympy.core.expr.Expr, symbols: List[sympy.core.symbol.Symbol]
+    expr: sympy.core.expr.Expr, symbols: List[str]
 ) -> ir.AffineMap:
     """
     Convert a sympy expression to an MLIR AffineMap using fractional algebra.

--- a/test/python/sympy_converter.py
+++ b/test/python/sympy_converter.py
@@ -18,7 +18,7 @@ def test_in_context(f):
 
 @test_in_context
 def test_basic_conversion():
-    symbols = [sympy.Symbol("x"), sympy.Symbol("y"), sympy.Symbol("z")]
+    symbols = ["x", "y", "z"]
 
     result = convert_sympy_to_affine_map(sympy.sympify("x + 2*y + 3"), symbols)
     # CHECK: ()[s0, s1, s2] -> (s0 + s1 * 2 + 3)
@@ -27,7 +27,7 @@ def test_basic_conversion():
 
 @test_in_context
 def test_mul_conversion():
-    symbols = [sympy.Symbol("x"), sympy.Symbol("y")]
+    symbols = ["x", "y"]
 
     try:
         convert_sympy_to_affine_map(sympy.sympify("x/4"), symbols)
@@ -86,7 +86,7 @@ def test_rational_conversion():
 
 @test_in_context
 def test_floor_ceil_conversion():
-    symbols = [sympy.Symbol("x"), sympy.Symbol("y"), sympy.Symbol("z")]
+    symbols = ["x", "y", "z"]
 
     # CHECK: ()[s0, s1, s2] -> ((s0 * 3) floordiv 2)
     print(convert_sympy_to_affine_map(sympy.sympify("floor(3*x/2)"), symbols))
@@ -117,7 +117,7 @@ def test_floor_ceil_conversion():
 
 @test_in_context
 def test_mod_conversion():
-    symbols = [sympy.Symbol("x"), sympy.Symbol("y")]
+    symbols = ["x", "y"]
 
     # CHECK: ()[s0, s1] -> (s0 mod s1)
     print(convert_sympy_to_affine_map(sympy.sympify("Mod(x, y)"), symbols))
@@ -129,7 +129,7 @@ def test_mod_conversion():
 
 @test_in_context
 def test_pow_conversion():
-    symbols = [sympy.Symbol("x"), sympy.Symbol("y")]
+    symbols = ["x", "y"]
 
     # CHECK: ()[s0, s1] -> ((s0 * s0) * s0)
     print(convert_sympy_to_affine_map(sympy.sympify("x^3"), symbols))


### PR DESCRIPTION
When converting sympy expression to affine map, we only care about the symbol names and not the exact `sympy.Symbol` objects. This allows the caller of `convert_sympy_to_affine_map` to freely add assumptions to the symbols (hence creating a new symbol with the same name) and substitute the original symbols in the expression.
