### PR TITLE
Allow Wave ops to use vector types directly

### DIFF
--- a/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -81,6 +81,8 @@ def NORMAL_FORM_OP_TYPES : I32BitEnumAttrCaseBit<
     "OpTypesSpecified",          1, "full_op_types">;
 def NORMAL_FORM_INDEX_EXPRS : I32BitEnumAttrCaseBit<
     "IndexExprsSpecified",       2, "index_exprs">;
+def NORMAL_FORM_MEMORY_ONLY_TYPES : I32BitEnumAttrCaseBit<
+    "MemoryOnlyTypes",           3, "memory_only_types">;
 
 def NORMAL_FORM_FULL_TYPES : I32BitEnumAttrCaseGroup<
     "AllTypesSpecified", [
@@ -93,6 +95,7 @@ def WaveNormalFormEnum : I32BitEnumAttr<"WaveNormalForm", "", [
   NORMAL_FORM_FUNC_BOUNDARY,
   NORMAL_FORM_OP_TYPES,
   NORMAL_FORM_INDEX_EXPRS,
+  NORMAL_FORM_MEMORY_ONLY_TYPES,
 
   // Group aliases.
   NORMAL_FORM_FULL_TYPES

--- a/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -350,8 +350,8 @@ public:
   }
 };
 
-// Trait implementing the methods of the WaveElementsPerThreadOpInterface one to
-// one between operands and results.
+// Trait implementing the methods of the WaveElementsPerThreadOpInterface with
+// information flowing between operands and results.
 template <typename OpTy>
 class IdentityElementsPerThreadOpTrait
     : public mlir::OpTrait::TraitBase<OpTy, IdentityElementsPerThreadOpTrait> {

--- a/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -17,6 +17,10 @@
 
 namespace wave {
 
+//-----------------------------------------------------------------------------
+// HasWaveIndexMapping trait
+//-----------------------------------------------------------------------------
+
 // Common verifier for the optional 'index' attribute used by Wave ops.
 mlir::LogicalResult verifyWaveIndexMappings(mlir::Operation *op);
 
@@ -34,6 +38,10 @@ mlir::ParseResult parseWaveIndexDict(mlir::OpAsmParser &parser,
                                      mlir::DictionaryAttr &out);
 void printWaveIndexDict(mlir::OpAsmPrinter &printer, mlir::Operation *op,
                         mlir::DictionaryAttr dict);
+
+//-----------------------------------------------------------------------------
+// WaveInferTypeOpInterface and implementation traits
+//-----------------------------------------------------------------------------
 
 namespace detail {
 // Propagate shape information from `from` tensor types to `to` tensor types.
@@ -173,6 +181,206 @@ public:
         op, /*includeAddressSpace=*/false);
   }
 };
+
+//-----------------------------------------------------------------------------
+// WaveElementsPerThreadOpInterface
+//-----------------------------------------------------------------------------
+
+// Lattice for propagating the "elements per thread" value across wave dialect
+// operations. In addition to the bottom and top states, it can represent a
+// concrete state manifest as an integer value. The JOIN function is defined by
+// the following table:
+//
+// JOIN       top         concrete        bottom
+// top        top         top             top
+// concrete   top         concrete|top*   concrete
+// bottom     top         concrete        bottom
+//   * if two concrete values are equal, their JOIN is equal to each of them,
+//     otherwise it is considered a propagation conflict and results in the top
+//     state.
+class ElementsPerThreadLatticeValue {
+public:
+  // Usage as lattice requires value/storage classes to be default- and
+  // copy-constructible, as well as copy-assignable.
+  ElementsPerThreadLatticeValue() : value(kBottomTag) {}
+  ElementsPerThreadLatticeValue(const ElementsPerThreadLatticeValue &) =
+      default;
+  ElementsPerThreadLatticeValue &
+  operator=(const ElementsPerThreadLatticeValue &other) = default;
+
+  // Create a lattice value in the concrete state.
+  explicit ElementsPerThreadLatticeValue(uint64_t value) : value(value) {
+    assert(value != kTopTag && "please use top() instead");
+    assert(value != kBottomTag && "please use bottom() instead");
+  }
+
+  // Create a lattice value in the bottom state.
+  static ElementsPerThreadLatticeValue bottom() {
+    ElementsPerThreadLatticeValue result(0);
+    result.value = kBottomTag;
+    return result;
+  }
+
+  // Create a lattice value in the top state.
+  static ElementsPerThreadLatticeValue top() {
+    ElementsPerThreadLatticeValue result(0);
+    result.value = kTopTag;
+    return result;
+  }
+
+  // Usage as lattice requires value/storage class instances to be comparable.
+  bool operator==(const ElementsPerThreadLatticeValue &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const ElementsPerThreadLatticeValue &other) const {
+    return !operator==(other);
+  }
+
+  // Examine the state of the lattice object.
+  bool isBottom() const { return value == kBottomTag; }
+  bool isTop() const { return value == kTopTag; }
+  uint64_t getValue() const {
+    assert(!isBottom() && !isTop());
+    return value;
+  }
+
+  // JOIN two lattice objects and return the result.
+  static ElementsPerThreadLatticeValue
+  join(const ElementsPerThreadLatticeValue &lhs,
+       const ElementsPerThreadLatticeValue &rhs);
+
+  // XXX: backward analysis calls `meet` instead of `join`, but it isn't related
+  // to the direction of the analysis. Just defer to join.
+  static ElementsPerThreadLatticeValue
+  meet(const ElementsPerThreadLatticeValue &lhs,
+       const ElementsPerThreadLatticeValue &rhs) {
+    return join(lhs, rhs);
+  }
+
+  // Forcibly assign the current value of the lattice. This MUST NOT be used in
+  // the transfer functions as it may be moving the instance back on the lattice
+  // and therefore breaking the analysis convergence guarantees due to
+  // non-monotonicity. This is useful during forceful initialization to override
+  // the quirk of the dataflow framework using the same function
+  // (`setToEntry/ExitState`) to both initialize the analysis and to indicate
+  // failure to analyze. Those functions can keep setting the lattice to the top
+  // state.
+  void unsafeSet(const ElementsPerThreadLatticeValue &value) {
+    this->value = value.value;
+  }
+
+  // Print the lattice value to the given output stream.
+  void print(llvm::raw_ostream &os) const;
+
+  LLVM_DUMP_METHOD void dump() const { print(llvm::errs()); }
+
+private:
+  uint64_t value;
+  constexpr const static uint64_t kBottomTag =
+      std::numeric_limits<uint64_t>::max() - 1;
+  constexpr const static uint64_t kTopTag =
+      std::numeric_limits<uint64_t>::max();
+};
+
+namespace detail {
+
+// Propagate elements per thread lattice values from the list in `from` to the
+// list in `to`. The lattice values in the `from` list are expected to be
+// compatible, i.e., their JOIN should not result in the top value unless one of
+// them is already the lattice top. Report errors about conflicts to the error
+// stream provided and return failure. Otherwise return whether any of the `to`
+// lattices was updated.
+llvm::FailureOr<mlir::ChangeResult> identityElementsPerThreadPropagate(
+    llvm::ArrayRef<ElementsPerThreadLatticeValue> from,
+    llvm::MutableArrayRef<ElementsPerThreadLatticeValue> to,
+    llvm::StringRef fromName, llvm::StringRef toName, llvm::raw_ostream &errs);
+
+// Propagate elements per thread lattice values from `from` to the
+// `mutableValues` list and check their compatibility with those in the
+// `immutableValues` list i.e., their JOIN should not result in the top value
+// unless one of them is already the lattice top. Report errors about conflicts
+// to the error stream provided and return failure. Otherwise return whether any
+// of the `mutableValues` lattices was updated.
+llvm::FailureOr<mlir::ChangeResult>
+checkAndPropagateElementsPerThreadFromConstant(
+    const ElementsPerThreadLatticeValue &from,
+    llvm::ArrayRef<ElementsPerThreadLatticeValue> immutableValues,
+    llvm::MutableArrayRef<ElementsPerThreadLatticeValue> mutableValues,
+    llvm::StringRef fromName, llvm::StringRef immutableName,
+    llvm::StringRef mutableName, llvm::raw_ostream &errs);
+
+} // namespace detail
+
+// Trait implementing the methods of the WaveElementsPerThreadOpInterface based
+// on the `elements_per_thead` attribute.
+template <typename OpTy>
+class AttrBasedElementsPerThreadOpTrait
+    : public mlir::OpTrait::TraitBase<OpTy, AttrBasedElementsPerThreadOpTrait> {
+public:
+  // Propagate `elements_per_thread` value to results.
+  llvm::FailureOr<mlir::ChangeResult> propagateElementsPerThreadForward(
+      llvm::ArrayRef<ElementsPerThreadLatticeValue> operandTypes,
+      llvm::MutableArrayRef<ElementsPerThreadLatticeValue> resultTypes,
+      llvm::raw_ostream &errs) {
+    std::optional<int64_t> elementsPerThread =
+        llvm::cast<OpTy>(this->getOperation()).getElementsPerThread();
+    if (!elementsPerThread)
+      return mlir::ChangeResult::NoChange;
+
+    return detail::checkAndPropagateElementsPerThreadFromConstant(
+        ElementsPerThreadLatticeValue(*elementsPerThread), operandTypes,
+        resultTypes, "elements_per_thread attribute", "operand", "result",
+        errs);
+  }
+
+  // Propagate `elements_per_thread` value to operands.
+  llvm::FailureOr<mlir::ChangeResult> propagateElementsPerThreadBackward(
+      llvm::MutableArrayRef<ElementsPerThreadLatticeValue> operandTypes,
+      llvm::ArrayRef<ElementsPerThreadLatticeValue> resultTypes,
+      llvm::raw_ostream &errs) {
+    std::optional<int64_t> elementsPerThread =
+        llvm::cast<OpTy>(this->getOperation()).getElementsPerThread();
+    if (!elementsPerThread)
+      return mlir::ChangeResult::NoChange;
+
+    return detail::checkAndPropagateElementsPerThreadFromConstant(
+        ElementsPerThreadLatticeValue(*elementsPerThread), resultTypes,
+        operandTypes, "elements_per_thread attribute", "result", "operand",
+        errs);
+  }
+};
+
+// Trait implementing the methods of the WaveElementsPerThreadOpInterface one to
+// one between operands and results.
+template <typename OpTy>
+class IdentityElementsPerThreadOpTrait
+    : public mlir::OpTrait::TraitBase<OpTy, IdentityElementsPerThreadOpTrait> {
+public:
+  // Propagate from operands to results.
+  llvm::FailureOr<mlir::ChangeResult> propagateElementsPerThreadForward(
+      llvm::ArrayRef<ElementsPerThreadLatticeValue> operandTypes,
+      llvm::MutableArrayRef<ElementsPerThreadLatticeValue> resultTypes,
+      llvm::raw_ostream &errs) {
+    return wave::detail::identityElementsPerThreadPropagate(
+        operandTypes, resultTypes, "operands", "results", errs);
+  }
+
+  // Propagate from results to operands.
+  llvm::FailureOr<mlir::ChangeResult> propagateElementsPerThreadBackward(
+      llvm::MutableArrayRef<ElementsPerThreadLatticeValue> operandTypes,
+      llvm::ArrayRef<ElementsPerThreadLatticeValue> resultTypes,
+      llvm::raw_ostream &errs) {
+    return wave::detail::identityElementsPerThreadPropagate(
+        resultTypes, operandTypes, "results", "operands", errs);
+  }
+};
+
+// Trait indicating to the elements per thread propagation analysis that the
+// operation intentionally does not use or affect elements per thread.
+template <typename OpTy>
+class NoOpElementsPerThreadOpTrait
+    : public mlir::OpTrait::TraitBase<OpTy, NoOpElementsPerThreadOpTrait> {};
+
 } // namespace wave
 
 #include "water/Dialect/Wave/IR/WaveOpInterfaces.h.inc"

--- a/include/water/Dialect/Wave/IR/WaveInterfaces.td
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.td
@@ -18,6 +18,68 @@ def HasWaveIndexMapping : NativeOpTrait<"HasWaveIndexMapping"> {
 }
 
 //-----------------------------------------------------------------------------
+// Elements-per-thread propagation interface and implementation traits
+//-----------------------------------------------------------------------------
+
+def WaveElementsPerThreadOpInterface
+    : OpInterface<"WaveElementsPerThreadOpInterface"> {
+  let description = [{
+    Interface capturing op-specific rules for inferring and propagating the
+    number of elements processed by each work item (thread) in the workgroup
+    when lowering the Wave dialect programming model to the SIMT programming
+    model. Each operation may indicate how to infer the elements per threads for
+    its results based on the operation itself and the elements per thread values
+    of its operands, and vice versa.
+
+    Several common implementations are provided via traits.
+  }];
+  let methods = [
+    InterfaceMethod<[{
+      Propagate elements per threads information from operands to results.
+      Expected to return failure when a conflict is detected after printing
+      a descriptive error messages to the error stream provided.
+      }],
+      "::llvm::FailureOr<mlir::ChangeResult>",
+      "propagateElementsPerThreadForward",
+      (ins "::llvm::ArrayRef<::wave::ElementsPerThreadLatticeValue>"
+               :$operandElements,
+           "::llvm::MutableArrayRef<::wave::ElementsPerThreadLatticeValue>"
+               :$resultElements,
+           "::llvm::raw_ostream &":$errs)
+    >,
+    InterfaceMethod<[{
+      Propagate elements per threads information from results to operands.
+      Expected to return failure when a conflict is detected after printing
+      a descriptive error messages to the error stream provided.
+      }],
+      "::llvm::FailureOr<mlir::ChangeResult>",
+      "propagateElementsPerThreadBackward",
+      (ins "::llvm::MutableArrayRef<::wave::ElementsPerThreadLatticeValue>"
+               :$operandElements,
+           "::llvm::ArrayRef<::wave::ElementsPerThreadLatticeValue>"
+               :$resultElements,
+           "::llvm::raw_ostream &":$errs)
+    >,
+  ];
+  let cppNamespace = "::wave";
+}
+
+def AttrBasedElementsPerThreadOpTrait
+    : NativeOpTrait<"AttrBasedElementsPerThreadOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
+def NoOpElementsPerThreadOpTrait
+    : NativeOpTrait<"NoOpElementsPerThreadOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
+def IdentityElementsPerThreadOpTrait
+    : NativeOpTrait<"IdentityElementsPerThreadOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
+//-----------------------------------------------------------------------------
 // WaveInferTypeOpInterface and implementation traits
 //-----------------------------------------------------------------------------
 

--- a/include/water/Dialect/Wave/IR/WaveInterfaces.td
+++ b/include/water/Dialect/Wave/IR/WaveInterfaces.td
@@ -37,7 +37,7 @@ def WaveElementsPerThreadOpInterface
     InterfaceMethod<[{
       Propagate elements per threads information from operands to results.
       Expected to return failure when a conflict is detected after printing
-      a descriptive error messages to the error stream provided.
+      a descriptive error message to the error stream provided.
       }],
       "::llvm::FailureOr<mlir::ChangeResult>",
       "propagateElementsPerThreadForward",
@@ -50,7 +50,7 @@ def WaveElementsPerThreadOpInterface
     InterfaceMethod<[{
       Propagate elements per threads information from results to operands.
       Expected to return failure when a conflict is detected after printing
-      a descriptive error messages to the error stream provided.
+      a descriptive error message to the error stream provided.
       }],
       "::llvm::FailureOr<mlir::ChangeResult>",
       "propagateElementsPerThreadBackward",

--- a/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/include/water/Dialect/Wave/IR/WaveOps.td
@@ -47,6 +47,7 @@ class WaveArithmeticOpDoc {
 class UnaryWaveOp<string mnemonic>
     : WaveOp<mnemonic,
          [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait,
+          WaveElementsPerThreadOpInterface, IdentityElementsPerThreadOpTrait,
           CompatibleOperandsAndResultsOpTrait]>,
       WaveArithmeticOpDoc {
   let arguments = !con((ins
@@ -64,6 +65,7 @@ class UnaryWaveOp<string mnemonic>
 class BinaryWaveOp<string mnemonic>
     : WaveOp<mnemonic,
          [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait,
+          WaveElementsPerThreadOpInterface, IdentityElementsPerThreadOpTrait,
           CompatibleOperandsAndResultsOpTrait]>,
       WaveArithmeticOpDoc {
   let arguments = !con((ins
@@ -223,6 +225,7 @@ def AllocateOp : WaveOp<"allocate"> {
 
 def ReadOp : WaveOp<"read", [
     WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait,
+    WaveElementsPerThreadOpInterface, AttrBasedElementsPerThreadOpTrait,
     CompatibleOperandsAndResultsIgnoreSpaceOpTrait]> {
   let summary = "Reads from memory";
   let description = [{
@@ -231,7 +234,9 @@ def ReadOp : WaveOp<"read", [
   }];
 
   let arguments = !con((ins
-    Arg<WaveTensorInMemory, "Tensor representing memory to read from">:$memory
+    Arg<WaveTensorInMemory, "Tensor representing memory to read from">:$memory,
+    Arg<OptionalAttr<I64Attr>,
+        "Number of elements processed by each thread">:$elements_per_thread
   ), commonArguments);
 
   let results = (outs
@@ -240,10 +245,13 @@ def ReadOp : WaveOp<"read", [
 
   let assemblyFormat = "$memory " # commonArgumentsSyntax # "attr-dict `:` "
                        "functional-type(operands, results)";
+
+  let hasVerifier = 1;
 }
 
 def RegisterOp : WaveOp<"register", [
-    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait]> {
+    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait,
+    NoOpElementsPerThreadOpTrait]> {
   let summary = "Defines a tensor value known to be placed in a register";
   let description = [{
     Defines a new register-resident tensor initialized with the given scalar
@@ -268,6 +276,7 @@ def RegisterOp : WaveOp<"register", [
 
 def WriteOp : WaveOp<"write", [
     WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait,
+    WaveElementsPerThreadOpInterface, AttrBasedElementsPerThreadOpTrait,
     CompatibleOperandsAndResultsIgnoreSpaceOpTrait]> {
   let summary = "Writes into memory";
   let description = [{
@@ -277,12 +286,16 @@ def WriteOp : WaveOp<"write", [
 
   let arguments = !con((ins
     Arg<WaveTensorInRegister, "Value to write">:$value_to_store,
-    Arg<WaveTensorInMemory, "Tensor representing memory to write into">:$memory
+    Arg<WaveTensorInMemory, "Tensor representing memory to write into">:$memory,
+    Arg<OptionalAttr<I64Attr>,
+        "Number of elements processed by each thread">:$elements_per_thread
   ), commonArguments);
 
   let assemblyFormat =
     "$value_to_store `,` $memory " # commonArgumentsSyntax # "attr-dict `:`"
-    "type($value_to_store) `,` type($memory)";
+    "qualified(type($value_to_store)) `,` qualified(type($memory))";
+
+   let hasVerifier = 1;
 }
 
 #endif // WATER_DIALECT_WAVE_WAVEOPS

--- a/include/water/Dialect/Wave/IR/WaveTypes.h
+++ b/include/water/Dialect/Wave/IR/WaveTypes.h
@@ -15,4 +15,14 @@
 #define GET_TYPEDEF_CLASSES
 #include "water/Dialect/Wave/IR/WaveTypes.h.inc"
 
+namespace wave {
+// Returns true if the given type is a Wave dialect tensor definitely living in
+// the register address space.
+[[maybe_unused]] static inline bool isaTensorInRegister(mlir::Type type) {
+  auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(type);
+  return tensorType &&
+         tensorType.getAddressSpaceValue() == wave::WaveAddressSpace::Register;
+}
+}; // namespace wave
+
 #endif // WATER_DIALECT_WAVE_IR_WAVETYPES_H

--- a/include/water/Dialect/Wave/IR/WaveTypes.td
+++ b/include/water/Dialect/Wave/IR/WaveTypes.td
@@ -10,6 +10,7 @@
 include "water/Dialect/Wave/IR/WaveAttrs.td"
 include "water/Dialect/Wave/IR/WaveDialect.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/CommonTypeConstraints.td"
 
 //-----------------------------------------------------------------------------
 // Tensor type
@@ -92,14 +93,14 @@ def WaveTensorAddressSpaceShared
   : CPred<"::llvm::cast<::wave::WaveTensorType>($_self).getAddressSpaceValue()"
           " == ::wave::WaveAddressSpace::Shared">;
 def WaveTensorAddressSpaceRegister
-  : CPred<"::llvm::cast<::wave::WaveTensorType>($_self).getAddressSpaceValue()"
-          " == ::wave::WaveAddressSpace::Register">;
+  : CPred<"::wave::isaTensorInRegister($_self)">;
 
 def WaveTensorInRegister : TypeConstraint<
-  And<[WaveTensorType.predicate,
-       Or<[WaveTensorAddressSpaceUnspecified, WaveTensorAddressSpaceRegister]>]>,
-  "Wave tensor in register",
-  WaveTensorType.cppType
+  Or<[WaveTensorAddressSpaceRegister,
+      And<[WaveTensorType.predicate, WaveTensorAddressSpaceUnspecified]>,
+      IsFixedVectorOfRankPred<[1]>]>,
+  "Wave tensor in register or a 1D vector",
+  "::mlir::Type"
 >;
 
 def WaveTensorInMemory : TypeConstraint<

--- a/include/water/Dialect/Wave/Transforms/Passes.td
+++ b/include/water/Dialect/Wave/Transforms/Passes.td
@@ -45,4 +45,31 @@ def WaterWaveInferTypesPass : Pass<"water-wave-infer-types"> {
   ];
 }
 
+def WaverWavePropagateElementsPerThreadPass
+    : Pass<"water-wave-propagate-elements-per-thread"> {
+  let summary = "Replace register-resident tensor types with vector types";
+  let description = [{
+    Performs forward and backward sparse dataflow analysis propagating
+    information necessary to deduce the number of elements that each operation
+    processes per thread. This information comes from either:
+
+      * TODO: specialized operations that have constraints on elements owned by
+        each thread, such as MMA;
+      * memory access operations with dedicated attributes;
+      * TODO: compilation options.
+
+    All operations using register-resident Wave dialect tensor types are
+    expected to implement WaveElementsPerThreadOpInterface or have the
+    NoOpElementsPerThreadOpTrait to propagate this information. Other traits
+    provide implementations for common cases.
+
+    Reports errors if a conflict is detected, for example, if a value is read
+    with 4 elements per thread and then written with 8 elements per thread or
+    used in a context where a different number is expected.
+
+    Rewrites the IR to replace register-resident tensor types with vector types
+    indicating the number of elements processed by each thread.
+  }];
+}
+
 #endif // WATER_DIALECT_WAVE_TRANSFORMS_PASSES

--- a/include/water/Dialect/Wave/Transforms/Passes.td
+++ b/include/water/Dialect/Wave/Transforms/Passes.td
@@ -45,7 +45,7 @@ def WaterWaveInferTypesPass : Pass<"water-wave-infer-types"> {
   ];
 }
 
-def WaverWavePropagateElementsPerThreadPass
+def WaterWavePropagateElementsPerThreadPass
     : Pass<"water-wave-propagate-elements-per-thread"> {
   let summary = "Replace register-resident tensor types with vector types";
   let description = [{

--- a/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -236,7 +236,7 @@ wave::detail::checkAndPropagateElementsPerThreadFromConstant(
       return mlir::failure();
     }
 
-    if (!(joined == toType)) {
+    if (joined != toType) {
       changeResult = mlir::ChangeResult::Change;
       toType = joined;
     }

--- a/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -16,6 +16,10 @@
 
 using namespace mlir;
 
+//-----------------------------------------------------------------------------
+// Index attribute verification
+//-----------------------------------------------------------------------------
+
 LogicalResult wave::verifyWaveIndexMappings(Operation *op) {
   // The attribute is optional.
   Attribute attribute = op->getAttr(wave::WaveDialect::kIndexExprAttrName);
@@ -65,6 +69,10 @@ LogicalResult wave::verifyWaveIndexMappings(Operation *op) {
   }
   return success();
 }
+
+//-----------------------------------------------------------------------------
+// Custom printing/parsing components
+//-----------------------------------------------------------------------------
 
 // ODS custom directive: parseWaveIndexDict/printWaveIndexDict
 ParseResult wave::parseWaveIndexDict(OpAsmParser &parser, DictionaryAttr &out) {
@@ -182,6 +190,96 @@ wave::detail::identityTypeInferencePropagate(
     changeResult |= *res;
   }
   return changeResult;
+}
+
+//-----------------------------------------------------------------------------
+// WaveElementsPerThreadOpInterface helpers
+//-----------------------------------------------------------------------------
+
+// Print the error message indicating a mismatch between the two lattices.
+static void printElementsPerThreadMismatchMsg(
+    llvm::raw_ostream &errs, const wave::ElementsPerThreadLatticeValue &from,
+    const wave::ElementsPerThreadLatticeValue &to, llvm::StringRef fromName,
+    llvm::StringRef toName, size_t toIndex) {
+  errs << "mismatch between " << fromName << " (";
+  from.print(errs);
+  errs << ") and " << toName << " #" << toIndex << " (";
+  to.print(errs);
+  errs << ")";
+}
+
+llvm::FailureOr<mlir::ChangeResult>
+wave::detail::checkAndPropagateElementsPerThreadFromConstant(
+    const ElementsPerThreadLatticeValue &from,
+    llvm::ArrayRef<ElementsPerThreadLatticeValue> immutableValues,
+    llvm::MutableArrayRef<ElementsPerThreadLatticeValue> mutableValues,
+    llvm::StringRef fromName, llvm::StringRef immutableName,
+    llvm::StringRef mutableName, llvm::raw_ostream &errs) {
+  for (auto [i, fr] : llvm::enumerate(immutableValues)) {
+    if (fr.isBottom() || ElementsPerThreadLatticeValue::join(from, fr) == fr)
+      continue;
+
+    printElementsPerThreadMismatchMsg(errs, from, fr, fromName, immutableName,
+                                      i);
+    return mlir::failure();
+  }
+
+  mlir::ChangeResult changeResult = mlir::ChangeResult::NoChange;
+  for (auto &&[i, toType] : llvm::enumerate(mutableValues)) {
+    ElementsPerThreadLatticeValue joined =
+        ElementsPerThreadLatticeValue::join(from, toType);
+
+    if (joined.isTop() && !from.isTop() && !toType.isTop()) {
+      printElementsPerThreadMismatchMsg(errs, from, toType, fromName,
+                                        mutableName, i);
+      toType = ElementsPerThreadLatticeValue::top();
+      return mlir::failure();
+    }
+
+    if (!(joined == toType)) {
+      changeResult = mlir::ChangeResult::Change;
+      toType = joined;
+    }
+  }
+  return changeResult;
+}
+
+llvm::FailureOr<mlir::ChangeResult>
+wave::detail::identityElementsPerThreadPropagate(
+    llvm::ArrayRef<ElementsPerThreadLatticeValue> from,
+    llvm::MutableArrayRef<ElementsPerThreadLatticeValue> to,
+    llvm::StringRef fromName, llvm::StringRef toName, llvm::raw_ostream &errs) {
+  assert(!from.empty());
+  assert(!to.empty());
+  return checkAndPropagateElementsPerThreadFromConstant(
+      from[0], from, to, (fromName + " #0").str(), fromName, toName, errs);
+}
+
+wave::ElementsPerThreadLatticeValue wave::ElementsPerThreadLatticeValue::join(
+    const wave::ElementsPerThreadLatticeValue &lhs,
+    const wave::ElementsPerThreadLatticeValue &rhs) {
+  if (lhs.isBottom())
+    return rhs;
+  if (rhs.isBottom())
+    return lhs;
+  if (lhs.isTop())
+    return lhs;
+  if (rhs.isTop())
+    return rhs;
+
+  // At this point, this is a specific lattice value.
+  if (lhs.value == rhs.value)
+    return lhs;
+  return top();
+}
+
+void wave::ElementsPerThreadLatticeValue::print(llvm::raw_ostream &os) const {
+  if (isBottom())
+    os << "<bottom>";
+  else if (isTop())
+    os << "<top>";
+  else
+    os << value;
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -24,7 +24,7 @@ using wave::ElementsPerThreadLatticeValue;
 
 namespace wave {
 #define GEN_PASS_DEF_WATERWAVEINFERTYPESPASS
-#define GEN_PASS_DEF_WAVERWAVEPROPAGATEELEMENTSPERTHREADPASS
+#define GEN_PASS_DEF_WATERWAVEPROPAGATEELEMENTSPERTHREADPASS
 #include "water/Dialect/Wave/Transforms/Passes.h.inc"
 } // namespace wave
 
@@ -771,11 +771,11 @@ public:
 
 // Elements-per-thread propagation pass implementation.
 class PropagateElementsPerThread
-    : public wave::impl::WaverWavePropagateElementsPerThreadPassBase<
+    : public wave::impl::WaterWavePropagateElementsPerThreadPassBase<
           PropagateElementsPerThread> {
 public:
-  using WaverWavePropagateElementsPerThreadPassBase::
-      WaverWavePropagateElementsPerThreadPassBase;
+  using WaterWavePropagateElementsPerThreadPassBase::
+      WaterWavePropagateElementsPerThreadPassBase;
 
   void runOnOperation() override {
     // Configure the analyses. The dead code and SCP analyses are required by

--- a/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -431,7 +431,7 @@ public:
 };
 
 // Run the dataflow analyses and capture whether some diagnostics were emitted.
-// Only emitted a generic diagnostic if no more specific diagnostic was emitted.
+// Only emit a generic diagnostic if no more specific diagnostic was emitted.
 // This is usually indicative of some deep internal problem in the dataflow
 // solver.
 static llvm::LogicalResult
@@ -459,7 +459,7 @@ runSolverAndCaptureErrors(mlir::DataFlowSolver &solver, mlir::Operation *root,
 }
 
 // Walk over all value definitions (op results and block arguments) and directly
-// set their types to ones using the inferred shape. Report error and stop if
+// set their types using the provided callback. Report error and stop if
 // any type failed to infer. Inferred types are supposed to still be accepted by
 // the op verifiers that will normally run after the pass.
 static llvm::LogicalResult updateValueTypes(
@@ -706,7 +706,8 @@ public:
   // Specialization of the dataflow transfer function for control flow branch
   // operation that are not forwarded to the branching target, so they cannot be
   // backpropagated from there. We do not expect this to happen so move the
-  // lattice instance to the top state, indicating a if this ever happens.
+  // lattice instance to the top state, indicating a conflict if this ever
+  // happens.
   void visitBranchOperand(mlir::OpOperand &opOperand) override {
     if (!wave::isaTensorInRegister(opOperand.get().getType()))
       return;
@@ -717,7 +718,8 @@ public:
   // Specialization of the dataflow transfer function for call operands that are
   // not forwarded to the callee. We do not expect register-resident types
   // handled by this analysis to be present at the function boundary so we move
-  // the lattice instance to the top state, indicating a if this ever happens.
+  // the lattice instance to the top state, indicating a conflict if this ever
+  // happens.
   void visitCallOperand(mlir::OpOperand &opOperand) override {
     if (!wave::isaTensorInRegister(opOperand.get().getType()))
       return;

--- a/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -20,15 +20,22 @@
 
 #define DEBUG_TYPE "wave-infer-types"
 
+using wave::ElementsPerThreadLatticeValue;
+
 namespace wave {
 #define GEN_PASS_DEF_WATERWAVEINFERTYPESPASS
+#define GEN_PASS_DEF_WAVERWAVEPROPAGATEELEMENTSPERTHREADPASS
 #include "water/Dialect/Wave/Transforms/Passes.h.inc"
 } // namespace wave
 
 namespace {
 
+//-----------------------------------------------------------------------------
+// WaveInferTypeOpInterface and implementation traits
+//-----------------------------------------------------------------------------
+
 // Core lattice for type/shape inference of wave tensors. In addition to the
-// bottom and top states, it can represent have a concrete type which may be
+// bottom and top states, it can represent a concrete type which may be
 // a fully specified tensor type (specific) or an underspecified type (any). The
 // JOIN function is defined by the following table:
 //
@@ -163,7 +170,7 @@ public:
 // manipulate wave tensor types, failure otherwise. Returns nullopt if the op
 // does implement the interface.
 static std::optional<llvm::LogicalResult>
-handleNonInterfaceOp(mlir::Operation *op) {
+handleNonInterfaceOpInferType(mlir::Operation *op) {
   if (llvm::isa<wave::WaveInferTypeOpInterface>(op))
     return std::nullopt;
 
@@ -242,7 +249,7 @@ public:
   visitOperation(mlir::Operation *op,
                  llvm::ArrayRef<const InferTypeLattice *> operands,
                  llvm::ArrayRef<InferTypeLattice *> results) override {
-    std::optional<mlir::LogicalResult> res = handleNonInterfaceOp(op);
+    std::optional<mlir::LogicalResult> res = handleNonInterfaceOpInferType(op);
     if (res)
       return *res;
 
@@ -329,12 +336,12 @@ public:
     if (getSolverConfig().isInterprocedural())
       return top->emitError() << "interprocedural analysis not supported";
 
-    if (mlir::failed(SparseBackwardDataFlowAnalysis::initialize(top)))
-      return mlir::failure();
-
     // Call the base class initialization in order to set up update listeners.
     // Note that this will initialize values at function/region entries to
     // lattice top.
+    if (mlir::failed(SparseBackwardDataFlowAnalysis::initialize(top)))
+      return mlir::failure();
+
     top->walk([this](mlir::Operation *op) {
       if (!op->hasTrait<mlir::OpTrait::ReturnLike>())
         return;
@@ -363,7 +370,7 @@ public:
   visitOperation(mlir::Operation *op,
                  llvm::ArrayRef<InferTypeLattice *> operands,
                  llvm::ArrayRef<const InferTypeLattice *> results) override {
-    std::optional<mlir::LogicalResult> res = handleNonInterfaceOp(op);
+    std::optional<mlir::LogicalResult> res = handleNonInterfaceOpInferType(op);
     if (res)
       return *res;
 
@@ -423,6 +430,67 @@ public:
   }
 };
 
+// Run the dataflow analyses and capture whether some diagnostics were emitted.
+// Only emitted a generic diagnostic if no more specific diagnostic was emitted.
+// This is usually indicative of some deep internal problem in the dataflow
+// solver.
+static llvm::LogicalResult
+runSolverAndCaptureErrors(mlir::DataFlowSolver &solver, mlir::Operation *root,
+                          bool force) {
+  bool emittedError = false;
+  mlir::DiagnosticEngine::HandlerID handlerID =
+      root->getContext()->getDiagEngine().registerHandler(
+          [&](mlir::Diagnostic &diag) {
+            if (diag.getSeverity() == mlir::DiagnosticSeverity::Error)
+              emittedError = true;
+
+            // Returning failure indicates that the diagnostic wan't handled
+            // and it is forwarded to other registered handlers.
+            return mlir::failure();
+          });
+  if (mlir::failed(solver.initializeAndRun(root))) {
+    if (!emittedError)
+      root->emitError() << "dataflow analysis failed";
+    if (!force)
+      return llvm::failure();
+  }
+  root->getContext()->getDiagEngine().eraseHandler(handlerID);
+  return llvm::success();
+}
+
+// Walk over all value definitions (op results and block arguments) and directly
+// set their types to ones using the inferred shape. Report error and stop if
+// any type failed to infer. Inferred types are supposed to still be accepted by
+// the op verifiers that will normally run after the pass.
+static llvm::LogicalResult updateValueTypes(
+    mlir::Operation *root,
+    llvm::function_ref<llvm::LogicalResult(mlir::Value, llvm::StringRef)>
+        updateType) {
+  mlir::WalkResult walkResult = root->walk([&](mlir::Operation *op) {
+    for (mlir::OpResult res : op->getResults()) {
+      if (mlir::failed(updateType(
+              res, "result #" + std::to_string(res.getResultNumber()))))
+        return mlir::WalkResult::interrupt();
+    }
+
+    for (mlir::Region &region : op->getRegions()) {
+      for (auto &&[blockNumber, block] : llvm::enumerate(region)) {
+        for (mlir::BlockArgument arg : block.getArguments()) {
+          auto fmt = llvm::formatv("argument #{0} of block #{1} in region #{2}",
+                                   arg.getArgNumber(), blockNumber,
+                                   region.getRegionNumber());
+          if (mlir::failed(updateType(arg, fmt.str())))
+            return mlir::WalkResult::interrupt();
+        }
+      }
+    }
+
+    return mlir::WalkResult::advance();
+  });
+
+  return llvm::failure(walkResult.wasInterrupted());
+}
+
 // Type inference pass implementation.
 class InferTypes : public wave::impl::WaterWaveInferTypesPassBase<InferTypes> {
 public:
@@ -446,28 +514,8 @@ public:
     solver.load<InferTypeBackwardAnalysis>(symbolTable);
     mlir::Operation *root = getOperation();
 
-    // Run the dataflow analyses and capture whether some diagnostics were
-    // emitted. Only emitted a generic diagnostic if no more specific diagnostic
-    // was emitted. This is usually indicative of some deep internal problem in
-    // the dataflow solver.
-    bool emittedError = false;
-    mlir::DiagnosticEngine::HandlerID handlerID =
-        getContext().getDiagEngine().registerHandler(
-            [&](mlir::Diagnostic &diag) {
-              if (diag.getSeverity() == mlir::DiagnosticSeverity::Error)
-                emittedError = true;
-
-              // Returning failure indicates that the diagnostic wan't handled
-              // and it is forwarded to other registered handlers.
-              return mlir::failure();
-            });
-    if (mlir::failed(solver.initializeAndRun(root))) {
-      if (!emittedError)
-        getOperation()->emitError() << "dataflow analysis failed";
-      if (!force)
-        return signalPassFailure();
-    }
-    getContext().getDiagEngine().eraseHandler(handlerID);
+    if (llvm::failed(runSolverAndCaptureErrors(solver, root, force)))
+      return signalPassFailure();
 
     // Update the type of the value given the lattice. Don't return failure
     // after emitting error if force-processing is requested.
@@ -490,40 +538,290 @@ public:
       return mlir::success();
     };
 
-    // Walk over all value definitions (op results and block arguments) and
-    // directly set their types to ones using the inferred shape. Report error
-    // and stop if any type failed to infer. Inferred types are supposed to
-    // still be accepted by the op verifiers that will normally run after the
-    // pass.
-    mlir::WalkResult walkResult =
-        getOperation()->walk([&](mlir::Operation *op) {
-          for (mlir::OpResult res : op->getResults()) {
-            if (mlir::failed(updateType(
-                    res, "result #" + std::to_string(res.getResultNumber()))))
-              return mlir::WalkResult::interrupt();
-          }
-
-          for (mlir::Region &region : op->getRegions()) {
-            for (auto &&[blockNumber, block] : llvm::enumerate(region)) {
-              for (mlir::BlockArgument arg : block.getArguments()) {
-                auto fmt = llvm::formatv(
-                    "argument #{0} of block #{1} in region #{2}",
-                    arg.getArgNumber(), blockNumber, region.getRegionNumber());
-                if (mlir::failed(updateType(arg, fmt.str())))
-                  return mlir::WalkResult::interrupt();
-              }
-            }
-          }
-
-          return mlir::WalkResult::advance();
-        });
-
-    if (walkResult.wasInterrupted())
+    if (llvm::failed(updateValueTypes(getOperation(), updateType)))
       return signalPassFailure();
 
     llvm::LogicalResult result = setNormalFormPassPostcondition(
         wave::WaveNormalForm::AllTypesSpecified, getOperation());
     if (llvm::failed(result) && !force)
+      return signalPassFailure();
+  }
+};
+
+//-----------------------------------------------------------------------------
+// WaveInferTypeOpInterface and implementation traits
+//-----------------------------------------------------------------------------
+
+// Typed lattice object for elements-per-thread dataflow propagation.
+class ElementsPerThreadLattice
+    : public mlir::dataflow::Lattice<ElementsPerThreadLatticeValue> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ElementsPerThreadLattice);
+  using Lattice::Lattice;
+};
+
+// Helper function for forward/backward inference handling ops that do not
+// implement the elements per thread propagation interface. Returns success if
+// the op doesn't manipulate register-resident wave tensor types, failure
+// otherwise. Returns nullopt if the op does implement the interface.
+static std::optional<llvm::LogicalResult>
+handleNonInterfaceOpElementsPerThread(mlir::Operation *op) {
+  if (llvm::isa<wave::WaveElementsPerThreadOpInterface>(op))
+    return std::nullopt;
+
+  if (llvm::none_of(op->getOperandTypes(), wave::isaTensorInRegister) &&
+      llvm::none_of(op->getResultTypes(), wave::isaTensorInRegister))
+    return llvm::success();
+
+  return op->emitError()
+         << "cannot propagate elements per thread information across an "
+            "operation not implementing the corresponding interface";
+}
+
+// Dataflow analysis propagating elements-per-thread information from operands
+// to results. This is an optimistic sparse context-insensitive forward dataflow
+// analysis intended for intra-procedural use and composition with the
+// equivalent backward analysis. It propagates information based on per-op
+// implementations of WaveElementsPerThreadOpInterface,
+// NoOpElementsPerThreadOpTrait as well as regular control flow interfaces until
+// convergence. In case of a conflict, e.g., the same value is used with
+// different number of elements per thread in two different IR contexts, reports
+// a diagnostic and sets the value lattice to the top state. If the analysis
+// fails due to the lack of information, e.g., control flow operations not
+// implementing the requested interfaces, the lattice instances may be set to
+// the top state without diagnostics. If insufficient information is available
+// in the IR, e.g., memory-related operations do not provide an explicit number
+// of elements per thread and there is no context allowing to infer them, the
+// lattice value remains set to bottom.
+class ElementsPerThreadForwardAnalysis
+    : public mlir::dataflow::SparseForwardDataFlowAnalysis<
+          ElementsPerThreadLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  // Basic initialization and configuration filtering.
+  mlir::LogicalResult initialize(mlir::Operation *top) override {
+    if (getSolverConfig().isInterprocedural())
+      return top->emitError() << "interprocedural analysis not supported";
+
+    // Call the base class initialization in order to set up update listeners.
+    // Note that this will initialize values at function/region entries to
+    // lattice top.
+    if (mlir::failed(AbstractSparseForwardDataFlowAnalysis::initialize(top)))
+      return mlir::failure();
+
+    return mlir::success();
+  }
+
+  // Called by base class initialization and when the analysis fails to identify
+  // lattices to join.
+  void setToEntryState(ElementsPerThreadLattice *lattice) override {
+    propagateIfChanged(lattice,
+                       lattice->join(ElementsPerThreadLatticeValue::top()));
+  }
+
+  // Dataflow transfer function, defers to either
+  // WaveElementsPerThreadOpInterface or NoOpElementsPerThreadOpTrait.
+  mlir::LogicalResult
+  visitOperation(mlir::Operation *op,
+                 llvm::ArrayRef<const ElementsPerThreadLattice *> operands,
+                 llvm::ArrayRef<ElementsPerThreadLattice *> results) override {
+    if (op->hasTrait<wave::NoOpElementsPerThreadOpTrait>())
+      return llvm::success();
+
+    std::optional<mlir::LogicalResult> res =
+        handleNonInterfaceOpElementsPerThread(op);
+    if (res)
+      return *res;
+
+    auto extractValue = [](const ElementsPerThreadLattice *lattice) {
+      return lattice->getValue();
+    };
+    llvm::SmallVector<ElementsPerThreadLatticeValue> operandElements =
+        llvm::map_to_vector(operands, extractValue);
+    llvm::SmallVector<ElementsPerThreadLatticeValue> resultElements =
+        llvm::map_to_vector(results, extractValue);
+
+    std::string errorMessage;
+    llvm::raw_string_ostream errs(errorMessage);
+    llvm::FailureOr<mlir::ChangeResult> result =
+        llvm::cast<wave::WaveElementsPerThreadOpInterface>(op)
+            .propagateElementsPerThreadForward(operandElements, resultElements,
+                                               errs);
+    if (llvm::failed(result)) {
+      return op->emitError()
+             << "failed to propagate elements per thread forward: "
+             << errs.str();
+    }
+    if (*result == mlir::ChangeResult::NoChange)
+      return mlir::success();
+
+    for (auto &&[result, lattice] : llvm::zip_equal(resultElements, results)) {
+      propagateIfChanged(lattice,
+                         lattice->join(ElementsPerThreadLatticeValue(result)));
+    }
+    return mlir::success();
+  }
+};
+
+// Dataflow analysis propagating elements-per-thread information from results
+// to operands. This is an optimistic sparse context-insensitive forward
+// dataflow analysis intended for intra-procedural use and composition with the
+// equivalent backward analysis. It propagates information based on per-op
+// implementations of WaveElementsPerThreadOpInterface,
+// NoOpElementsPerThreadOpTrait as well as regular control flow interfaces until
+// convergence. In case of a conflict, e.g., the same value is used with
+// different number of elements per thread in two different IR contexts, reports
+// a diagnostic and sets the value lattice to the top state. If the analysis
+// fails due to the lack of information, e.g., control flow operations not
+// implementing the requested interfaces, the lattice instances may be set to
+// the top state without diagnostics. If insufficient information is available
+// in the IR, e.g., memory-related operations do not provide an explicit number
+// of elements per thread and there is no context allowing to infer them, the
+// lattice value remains set to bottom.
+class ElementsPerThreadBackwardAnalysis
+    : public mlir::dataflow::SparseBackwardDataFlowAnalysis<
+          ElementsPerThreadLattice> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  // Basic initialization and configuration filtering.
+  mlir::LogicalResult initialize(mlir::Operation *top) override {
+    if (getSolverConfig().isInterprocedural())
+      return top->emitError() << "interprocedural analysis not supported";
+
+    if (mlir::failed(SparseBackwardDataFlowAnalysis::initialize(top)))
+      return mlir::failure();
+
+    return mlir::success();
+  }
+
+  // Called by base class initialization and when the analysis fails to identify
+  // lattices to join.
+  void setToExitState(ElementsPerThreadLattice *lattice) override {
+    propagateIfChanged(lattice,
+                       lattice->join(ElementsPerThreadLatticeValue::top()));
+  }
+
+  // Specialization of the dataflow transfer function for control flow branch
+  // operation that are not forwarded to the branching target, so they cannot be
+  // backpropagated from there. We do not expect this to happen so move the
+  // lattice instance to the top state, indicating a if this ever happens.
+  void visitBranchOperand(mlir::OpOperand &opOperand) override {
+    if (!wave::isaTensorInRegister(opOperand.get().getType()))
+      return;
+
+    setToExitState(getLatticeElement(opOperand.get()));
+  }
+
+  // Specialization of the dataflow transfer function for call operands that are
+  // not forwarded to the callee. We do not expect register-resident types
+  // handled by this analysis to be present at the function boundary so we move
+  // the lattice instance to the top state, indicating a if this ever happens.
+  void visitCallOperand(mlir::OpOperand &opOperand) override {
+    if (!wave::isaTensorInRegister(opOperand.get().getType()))
+      return;
+
+    setToExitState(getLatticeElement(opOperand.get()));
+  }
+
+  // Dataflow transfer function, defers to either
+  // WaveElementsPerThreadOpInterface or NoOpElementsPerThreadOpTrait.
+  llvm::LogicalResult visitOperation(
+      mlir::Operation *op, llvm::ArrayRef<ElementsPerThreadLattice *> operands,
+      llvm::ArrayRef<const ElementsPerThreadLattice *> results) override {
+    if (op->hasTrait<wave::NoOpElementsPerThreadOpTrait>())
+      return llvm::success();
+
+    std::optional<mlir::LogicalResult> res =
+        handleNonInterfaceOpElementsPerThread(op);
+    if (res)
+      return *res;
+
+    auto extractValue = [](const ElementsPerThreadLattice *lattice) {
+      return lattice->getValue();
+    };
+    llvm::SmallVector<ElementsPerThreadLatticeValue> operandElements =
+        llvm::map_to_vector(operands, extractValue);
+    llvm::SmallVector<ElementsPerThreadLatticeValue> resultElements =
+        llvm::map_to_vector(results, extractValue);
+
+    std::string errorMessage;
+    llvm::raw_string_ostream errs(errorMessage);
+    llvm::FailureOr<mlir::ChangeResult> result =
+        llvm::cast<wave::WaveElementsPerThreadOpInterface>(op)
+            .propagateElementsPerThreadBackward(operandElements, resultElements,
+                                                errs);
+    if (llvm::failed(result)) {
+      return op->emitError()
+             << "failed to propagate elements per thread backward: "
+             << errs.str();
+    }
+    if (*result == mlir::ChangeResult::NoChange)
+      return llvm::success();
+
+    for (auto &&[operand, lattice] :
+         llvm::zip_equal(operandElements, operands)) {
+      propagateIfChanged(lattice,
+                         lattice->join(ElementsPerThreadLatticeValue(operand)));
+    }
+    return llvm::success();
+  }
+};
+
+// Elements-per-thread propagation pass implementation.
+class PropagateElementsPerThread
+    : public wave::impl::WaverWavePropagateElementsPerThreadPassBase<
+          PropagateElementsPerThread> {
+public:
+  using WaverWavePropagateElementsPerThreadPassBase::
+      WaverWavePropagateElementsPerThreadPassBase;
+
+  void runOnOperation() override {
+    // Configure the analyses. The dead code and SCP analyses are required by
+    // the logic of the solver currently.
+    mlir::SymbolTableCollection symbolTable;
+    mlir::DataFlowConfig dataFlowConfig;
+    dataFlowConfig.setInterprocedural(false);
+    mlir::DataFlowSolver solver(dataFlowConfig);
+    solver.load<mlir::dataflow::DeadCodeAnalysis>();
+    solver.load<mlir::dataflow::SparseConstantPropagation>();
+    solver.load<ElementsPerThreadForwardAnalysis>();
+    solver.load<ElementsPerThreadBackwardAnalysis>(symbolTable);
+
+    if (llvm::failed(runSolverAndCaptureErrors(solver, getOperation(), false)))
+      return signalPassFailure();
+
+    auto updateType = [&](mlir::Value value, llvm::StringRef description) {
+      auto tensorType = llvm::dyn_cast<wave::WaveTensorType>(value.getType());
+      if (!tensorType ||
+          tensorType.getAddressSpaceValue() != wave::WaveAddressSpace::Register)
+        return llvm::success();
+
+      const auto *lattice = solver.lookupState<ElementsPerThreadLattice>(value);
+      if (!lattice || lattice->getValue().isBottom()) {
+        emitError(value.getLoc())
+            << "couldn't identify elements per thread for " << description;
+        return llvm::failure();
+      }
+      if (lattice->getValue().isTop()) {
+        emitError(value.getLoc())
+            << "elements per thread conflict was detected for " << description;
+        return llvm::failure();
+      }
+
+      auto vectorType = mlir::VectorType::get(
+          {static_cast<int64_t>(lattice->getValue().getValue())},
+          tensorType.getElementType());
+      value.setType(vectorType);
+      return llvm::success();
+    };
+
+    if (llvm::failed(updateValueTypes(getOperation(), updateType)))
+      return signalPassFailure();
+
+    if (llvm::failed(wave::setNormalFormPassPostcondition(
+            wave::WaveNormalForm::MemoryOnlyTypes, getOperation())))
       return signalPassFailure();
   }
 };

--- a/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -41,7 +41,9 @@ struct LowerWaveToMLIRPass
 
     // TODO: require index expressions to be present
     if (failed(wave::verifyNormalFormPassPrecondition(
-            wave::WaveNormalForm::AllTypesSpecified, op, getPassName())))
+            wave::WaveNormalForm::AllTypesSpecified |
+                wave::WaveNormalForm::MemoryOnlyTypes,
+            op, getPassName())))
       return signalPassFailure();
 
     ConversionTarget target(*ctx);
@@ -51,8 +53,18 @@ struct LowerWaveToMLIRPass
     ConversionConfig config;
     config.allowPatternRollback = false;
 
+    auto *waveDialect = getContext().getLoadedDialect<wave::WaveDialect>();
     WalkResult walkResult =
         getOperation()->walk<WalkOrder::PreOrder>([&](Operation *op) {
+          // We shouldn't hit standalone Wave dialect operations as we are
+          // walking in preorder.
+          // TODO: consider turning this into a normalform.
+          if (op->getDialect() == waveDialect) {
+            op->emitError() << "wave dialect operation with no hyperparameters "
+                               "provided by any ancestor";
+            return WalkResult::interrupt();
+          }
+
           auto hyperparam = op->getAttrOfType<wave::WaveHyperparameterAttr>(
               wave::WaveDialect::kHyperparameterAttrName);
           if (!hyperparam)
@@ -69,6 +81,8 @@ struct LowerWaveToMLIRPass
             op->emitError() << "failed to convert starting at this operation";
             return WalkResult::interrupt();
           }
+
+          op->removeAttr(wave::WaveDialect::kHyperparameterAttrName);
           return WalkResult::skip();
         });
     if (walkResult.wasInterrupted())

--- a/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -99,16 +99,13 @@ public:
   LogicalResult
   matchAndRewrite(WaveOp op, typename WaveOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type convertedType = this->getTypeConverter()->convertType(op);
+    Type convertedType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
     if (!convertedType) {
       return rewriter.notifyMatchFailure(op,
                                          "WaveTensorType conversion failed");
     }
-    auto vectorType = dyn_cast<VectorType>(convertedType);
-    if (!vectorType) {
-      return rewriter.notifyMatchFailure(op,
-                                         "expected vector type for binary op");
-    }
+    auto vectorType = cast<VectorType>(convertedType);
 
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
@@ -152,16 +149,13 @@ public:
   LogicalResult
   matchAndRewrite(wave::RegisterOp op, wave::RegisterOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type convertedType = getTypeConverter()->convertType(op);
+    Type convertedType =
+        getTypeConverter()->convertType(op.getResult().getType());
     if (!convertedType) {
       return rewriter.notifyMatchFailure(op,
                                          "WaveTensorType conversion failed");
     }
-    auto vectorType = dyn_cast<VectorType>(convertedType);
-    if (!vectorType) {
-      return rewriter.notifyMatchFailure(
-          op, "expected vector type after conversion");
-    }
+    auto vectorType = cast<VectorType>(convertedType);
 
     TypedAttr splatAttr;
     Value initValue = op.getInit();

--- a/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -1,55 +1,67 @@
-// RUN: water-opt %s -allow-unregistered-dialect -lower-wave-to-mlir -split-input-file | FileCheck %s
+// RUN: water-opt %s -allow-unregistered-dialect -lower-wave-to-mlir -split-input-file --verify-diagnostics | FileCheck %s
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @no_hyperparams() {
+    %cst = arith.constant 0.0 : f32
+    // expected-error @below {{wave dialect operation with no hyperparameters provided by any ancestor}}
+    wave.register %cst : vector<4xf32>
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @lower_register
-  func.func @lower_register() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+  func.func @lower_register() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.register
-    // CHECK:     arith.constant dense<0.000000e+00> : vector<10x1xf32>
+    // CHECK:     arith.constant dense<0.000000e+00> : vector<4xf32>
     %cst = arith.constant 0.0 : f32
-    wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+    wave.register %cst : vector<4xf32>
 
-    // CHECK:     arith.constant dense<1.000000e+00> : vector<10x1x100xf32>
+    // CHECK:     arith.constant dense<1.000000e+00> : vector<4xf32>
     %cst1 = arith.constant 1.0 : f32
-    wave.register %cst1 : !wave.tensor<[@Y, @Z, @X] of f32, <register>>
+    wave.register %cst1 : vector<4xf32>
 
-    // CHECK:     arith.constant dense<2> : vector<10x1x100xi32>
+    // CHECK:     arith.constant dense<2> : vector<8xi32>
     %cst2 = arith.constant 2 : i32
-    wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    wave.register %cst2 : vector<8xi32>
     return
   }
 }
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @lower_register_with_unrealized_cast
-  func.func @lower_register_with_unrealized_cast() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+  func.func @lower_register_with_unrealized_cast() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 10, Z = 1, BLOCK_M = 1, BLOCK_K = 2}>} {
     // CHECK-NOT: wave.register
-    // CHECK:     %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<10x1xf32>
-    // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[CST]] : vector<10x1xf32> to !wave.tensor<[@Y, @Z] of f32, <register>>
+    // CHECK:     %[[ALLOC:.*]] = memref.alloc() : memref<1x6xf32, #gpu.address_space<workgroup>>
+    // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]] : memref<1x6xf32, #gpu.address_space<workgroup>> to !wave.tensor<[@Y, @Z] of f32, <shared>>
     // CHECK:     "test.foo"(%[[CAST]])
-    %cst = arith.constant 0.0 : f32
-    %0 = wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
-    "test.foo"(%0) : (!wave.tensor<[@Y, @Z] of f32, <register>>) -> ()
+    %0 = wave.allocate
+    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
+    : !wave.tensor<[@Y, @Z] of f32, <shared>>
+    "test.foo"(%0) : (!wave.tensor<[@Y, @Z] of f32, <shared>>) -> ()
     return
   }
 }
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @lower_nested_register
-  func.func @lower_nested_register(%cond: i1) attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+  func.func @lower_nested_register(%cond: i1) attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.register
     scf.if %cond {
-      // CHECK:     arith.constant dense<0.000000e+00> : vector<10x1xf32>
+      // CHECK:     arith.constant dense<0.000000e+00> : vector<1xf32>
       %cst = arith.constant 0.0 : f32
-      wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+      wave.register %cst : vector<1xf32>
       scf.yield
     } else {
-      // CHECK:     arith.constant dense<1.000000e+00> : vector<10x1x100xf32>
+      // CHECK:     arith.constant dense<1.000000e+00> : vector<1xf32>
       %cst1 = arith.constant 1.0 : f32
-      wave.register %cst1 : !wave.tensor<[@Y, @Z, @X] of f32, <register>>
+      wave.register %cst1 : vector<1xf32>
       scf.yield
     }
     return
@@ -58,27 +70,27 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @lower_add
-  func.func @lower_add() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+  func.func @lower_add() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.add
-    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
-    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
-    // CHECK:     arith.addf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<4xf32>
+    // CHECK:     arith.addf %[[LHS]], %[[RHS]] : vector<4xf32>
     %cst = arith.constant 0.0 : f32
-    %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %lhs = wave.register %cst : vector<4xf32>
     %cst1 = arith.constant 1.0 : f32
-    %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-    %addf = wave.add %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %rhs = wave.register %cst1 : vector<4xf32>
+    %addf = wave.add %lhs, %rhs : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
-    // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<10x1x100xi32>
-    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
-    // CHECK:     arith.addi %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<2xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<2xi32>
+    // CHECK:     arith.addi %[[LHSI]], %[[RHSI]] : vector<2xi32>
     %cst2 = arith.constant 2 : i32
-    %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %lhsi = wave.register %cst2 : vector<2xi32>
     %cst3 = arith.constant 3 : i32
-    %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-    %addi = wave.add %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %rhsi = wave.register %cst3 : vector<2xi32>
+    %addi = wave.add %lhsi, %rhsi : (vector<2xi32>, vector<2xi32>) -> vector<2xi32>
 
     return
   }
@@ -86,27 +98,27 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @lower_mul
-  func.func @lower_mul() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+  func.func @lower_mul() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.mul
-    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
-    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
-    // CHECK:     arith.mulf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<4xf32>
+    // CHECK:     arith.mulf %[[LHS]], %[[RHS]] : vector<4xf32>
     %cst = arith.constant 0.0 : f32
-    %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %lhs = wave.register %cst : vector<4xf32>
     %cst1 = arith.constant 1.0 : f32
-    %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-    %mulf = wave.mul %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %rhs = wave.register %cst1 : vector<4xf32>
+    %mulf = wave.mul %lhs, %rhs : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
-    // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<10x1x100xi32>
-    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
-    // CHECK:     arith.muli %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<2> : vector<4xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<4xi32>
+    // CHECK:     arith.muli %[[LHSI]], %[[RHSI]] : vector<4xi32>
     %cst2 = arith.constant 2 : i32
-    %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %lhsi = wave.register %cst2 : vector<4xi32>
     %cst3 = arith.constant 3 : i32
-    %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-    %muli = wave.mul %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %rhsi = wave.register %cst3 : vector<4xi32>
+    %muli = wave.mul %lhsi, %rhsi : (vector<4xi32>, vector<4xi32>) -> vector<4xi32>
 
     return
   }
@@ -114,27 +126,27 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @lower_div
-  func.func @lower_div() attributes {wave.hyperparameters = #wave.hyperparameters<{X = 100, Y = 10, Z = 1}>} {
+  func.func @lower_div() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.div
-    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<100x10x1xf32>
-    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<100x10x1xf32>
-    // CHECK:     arith.divf %[[LHS]], %[[RHS]] : vector<100x10x1xf32>
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<1.000000e+00> : vector<4xf32>
+    // CHECK:     arith.divf %[[LHS]], %[[RHS]] : vector<4xf32>
     %cst = arith.constant 0.0 : f32
-    %lhs = wave.register %cst : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %lhs = wave.register %cst : vector<4xf32>
     %cst1 = arith.constant 1.0 : f32
-    %rhs = wave.register %cst1 : !wave.tensor<[@X, @Y, @Z] of f32, <register>>
-    %divf = wave.div %lhs, %rhs : (!wave.tensor<[@X, @Y, @Z] of f32, <register>>, !wave.tensor<[@X, @Y, @Z] of f32, <register>>) -> !wave.tensor<[@X, @Y, @Z] of f32, <register>>
+    %rhs = wave.register %cst1 : vector<4xf32>
+    %divf = wave.div %lhs, %rhs : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
-    // CHECK:     %[[LHSI:.*]] = arith.constant dense<-2> : vector<10x1x100xi32>
-    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<10x1x100xi32>
-    // CHECK:     arith.divsi %[[LHSI]], %[[RHSI]] : vector<10x1x100xi32>
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<-2> : vector<4xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<4xi32>
+    // CHECK:     arith.divsi %[[LHSI]], %[[RHSI]] : vector<4xi32>
     %cst2 = arith.constant -2 : i32
-    %lhsi = wave.register %cst2 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %lhsi = wave.register %cst2 : vector<4xi32>
     %cst3 = arith.constant 3 : i32
-    %rhsi = wave.register %cst3 : !wave.tensor<[@Y, @Z, @X] of i32, <register>>
-    %divsi = wave.div %lhsi, %rhsi : (!wave.tensor<[@Y, @Z, @X] of i32, <register>>, !wave.tensor<[@Y, @Z, @X] of i32, <register>>) -> !wave.tensor<[@Y, @Z, @X] of i32, <register>>
+    %rhsi = wave.register %cst3 : vector<4xi32>
+    %divsi = wave.div %lhsi, %rhsi : (vector<4xi32>, vector<4xi32>) -> vector<4xi32>
 
     return
   }
@@ -142,7 +154,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
 // CHECK-LABEL: func.func @lower_alloc_view
 func.func @lower_alloc_view() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
   // CHECK: %[[BUFF:.*]] = memref.alloc() : memref<256xi8, #gpu.address_space<workgroup>>
@@ -161,14 +173,13 @@ func.func @lower_alloc_view() attributes {wave.hyperparameters = #wave.hyperpara
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
 // CHECK-LABEL: @lower_alloc
-func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
+func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, K= 128}>}  {
   // CHECK: memref.alloc() : memref<4x32xbf16, #gpu.address_space<workgroup>>
   %buf = wave.allocate
     { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
-  wave.read %buf : (!wave.tensor<[@M, @K] of bf16, <shared>>) -> !wave.tensor<[@M, @K] of bf16, <register>>
   return
   }
 }

--- a/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -1,0 +1,148 @@
+// RUN: water-opt %s --water-wave-propagate-elements-per-thread --split-input-file --verify-diagnostics --allow-unregistered-dialect | FileCheck %s
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  func.func @register_alone() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 10, Z = 1}>} {
+    %cst = arith.constant 0.0 : f32
+    // expected-error @below {{couldn't identify elements per thread for result #0}}
+    wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+  func.func @register_add() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 10, Z = 1}>} {
+    %cst = arith.constant 0.0 : f32
+    // expected-error @below {{couldn't identify elements per thread for result #0}}
+    %reg = wave.register %cst { elements_per_thread = 4 } : !wave.tensor<[@Y, @Z] of f32, <register>>
+    wave.add %reg, %reg : (!wave.tensor<[@Y, @Z] of f32, <register>>, !wave.tensor<[@Y, @Z] of f32, <register>>) -> !wave.tensor<[@Y, @Z] of f32, <register>>
+    return
+  }
+}
+
+// -----
+
+// CHECK: #wave.normal_form<memory_only_types>
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+// CHECK-LABEL: @propagate_register_write
+func.func @propagate_register_write(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  %cst = arith.constant 0.0 : f16
+  // CHECK: wave.register {{.*}} : vector<8xf16>
+  %reg = wave.register %cst : !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.write {{.*}} : vector<8xf16>, !wave.tensor<[@M] of f16, <global>>
+  wave.write %reg, %mem { elements_per_thread = 8 }
+     : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  return
+}
+}
+
+// -----
+
+// CHECK: #wave.normal_form<memory_only_types>
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+// CHECK-LABEL: @propagate_backward_from_write
+func.func @propagate_backward_from_write(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  %cst = arith.constant 0.0 : f16
+  // CHECK: wave.register {{.*}} : vector<8xf16>
+  %reg = wave.register %cst : !wave.tensor<[@M] of f16, <register>>
+  %cst2 = arith.constant 42.0 : f16
+  // CHECK: wave.register {{.*}} : vector<8xf16>
+  %reg2 = wave.register %cst2 : !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.add {{.*}} : (vector<8xf16>, vector<8xf16>) -> vector<8xf16>
+  %sum = wave.add %reg, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.mul {{.*}} : (vector<8xf16>, vector<8xf16>) -> vector<8xf16>
+  %mul = wave.mul %sum, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.exp2 {{.*}} : (vector<8xf16>) -> vector<8xf16>
+  %exp = wave.exp2 %mul : (!wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+
+  // CHECK: wave.write {{.*}} : vector<8xf16>, !wave.tensor<[@M] of f16, <global>>
+  wave.write %exp, %mem { elements_per_thread = 8 }
+     : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  return
+}
+}
+
+// -----
+
+// CHECK: #wave.normal_form<memory_only_types>
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+// CHECK-LABEL: @propagate_forward_from_read
+func.func @propagate_forward_from_read(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  // CHECK: wave.read {{.*}} : (!wave.tensor<[@M] of f16, <global>>) -> vector<4xf16>
+  %reg = wave.read %mem { elements_per_thread = 4 } : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+  %cst2 = arith.constant 42.0 : f16
+  // CHECK: wave.register {{.*}} : vector<4xf16>
+  %reg2 = wave.register %cst2 : !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.add {{.*}} : (vector<4xf16>, vector<4xf16>) -> vector<4xf16>
+  %sum = wave.add %reg, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.mul {{.*}} : (vector<4xf16>, vector<4xf16>) -> vector<4xf16>
+  %mul = wave.mul %sum, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.exp2 {{.*}} : (vector<4xf16>) -> vector<4xf16>
+  %exp = wave.exp2 %mul : (!wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+
+  return
+}
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+func.func @missing_elements_per_thread(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  // expected-error @below {{couldn't identify elements per thread for result #0}}
+  %reg = wave.read %mem : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+  return
+}
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+func.func @read_write_conflict(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  %reg = wave.read %mem {elements_per_thread = 4} : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+  // expected-error @below {{failed to propagate elements per thread backward: mismatch between elements_per_thread attribute (8) and operand #0 (4)}}
+  wave.write %reg, %mem {elements_per_thread = 8} : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  return
+}
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+func.func @read_write_conflict_indirect(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  %reg = wave.read %mem {elements_per_thread = 4} : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+  %val = wave.exp2 %reg : (!wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  // expected-error @below {{failed to propagate elements per thread backward: mismatch between elements_per_thread attribute (8) and operand #0 (4)}}
+  wave.write %reg, %mem {elements_per_thread = 8} : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  return
+}
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+// CHECK-LABEL: func.func @alloc_is_harmless
+func.func @alloc_is_harmless() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
+  // CHECK: wave.allocate
+  %parent = wave.allocate { distributed_shape = #wave.distributed_shape<[] -> (256)> }
+    : !wave.tensor<[@M,@N,@K] of i8, <shared>>
+
+  // CHECK: wave.allocate
+  %buf = wave.allocate in %parent : !wave.tensor<[@M,@N,@K] of i8, <shared>>
+    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
+    : !wave.tensor<[@M, @K] of bf16, <shared>>
+  return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types>} {
+func.func @unsupported_op() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 100, Z = 200}>}  {
+  %cst = arith.constant 42.0 : f32
+  %reg = wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+  // expected-error @below {{cannot propagate elements per thread information across an operation not implementing the corresponding interface}}
+  "foo.bar"(%reg) : (!wave.tensor<[@Y, @Z] of f32, <register>>) -> !wave.tensor<[@Y, @Z] of f32, <register>>
+  return
+}
+}


### PR DESCRIPTION
Completely overhaul the lowering procedure for register-resident Wave
dialect tensors. They are representing values that are virtually
distributed across multiple threads. When lowering to core MLIR
dialects, we also perform a programming model change: the lowered IR is
expected to be SIMT. Therefore, register-resident Wave dialect tensors
should be converted to vectors of a _distributed_ shape rather than a
shape that comes from direct substitution of symbolic values from
hyperparameters (unlike memory-resident tensors).

The distributed per-thread shape of the vector is derived from the
"elements per thread" property available on memory operations, in
hyperparameters and compilation options, or extracted from intrinsic
structure of the MMA operation. Implement a dataflow analysis for
propagating this value from the property for now and report eventual
conflicts.

Based on the above dataflow analysis, implement a pass rewriting
register-resident Wave dialect tensors to vectors with distributed
shapes. Note that this _cannot_ be implemented as a dialect conversion
(or at least is significantly complicated) since the type conversion
depends on the result of the analysis, and not only on the original type
or defining operation.

This in turn requires extending Wave dialect operations to also accept
vector-typed values whenever a register-resident tensor is accepted.
This is not a significant departure from the original representation as
both tensors and vectors are immutable SSA values.

Introduce an additional normalform checking for the absence of
register-resident tensors in the input IR and make it a precondition of
the lowering pass, and a postcondition of the elements-per-thread
propagation pass.