### PR TITLE
rename DistributedShapeAttr to ShapeExprAttr to generalize

### DIFF
--- a/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -208,11 +208,14 @@ def WaveHyperparameterAttr : AttrDef<WaveDialect, "WaveHyperparameter"> {
   }];
 }
 
-def WaveDistributedShapeAttr : AttrDef<WaveDialect, "DistributedShape"> {
-  let mnemonic = "distributed_shape";
+def WaveExprAttr : AttrDef<WaveDialect, "Expr"> {
+  let mnemonic = "expr";
   let description = [{
-    Distributed (physical) tensor shape as affine expressions over named
-    Wave symbols.
+  A tuple of affine expressions over named Wave symbols.
+  This attribute is used to encode:
+    • Bounds expressions for read/write ops
+    • Distributed (physical) shapes for allocations
+
     Stores:
       - symbol_names: [WaveSymbolAttr] giving names (e.g., M, BLOCK_M, BLOCK_K)
       The i-th name maps to the s<i> in the affine expressions
@@ -220,7 +223,7 @@ def WaveDistributedShapeAttr : AttrDef<WaveDialect, "DistributedShape"> {
       Each result expr_k defines the k-th physical dimension.
 
       Parsing/printing:
-      #wave.distributed_shape<[M, K] -> (M, K+4)>
+      #wave.expr<[M, K] -> (M, K+4)>
   }];
 
   let parameters = (ins
@@ -242,12 +245,12 @@ def WaveReadWriteBoundsAttr : AttrDef<WaveDialect, "WaveReadWriteBounds"> {
   let mnemonic = "read_write_bounds";
   let description = [{
     This attribute contains a dictionary mapping from symbolic dimension (strings)
-    to a WaveDistributedShapeAttr specifying the bounds of the read/write operations
+    to a WaveExprAttr specifying the bounds of the read/write operations
     this is attached to.
 
     Example:
     ```
-    #wave.read_write_bounds<{M = #wave.distributed_shape<[BLOCK_M] -> BLOCK_M * 2>}>
+    #wave.read_write_bounds<{M = #wave.expr<[BLOCK_M] -> BLOCK_M * 2>}>
     ```
   }];
 

--- a/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/include/water/Dialect/Wave/IR/WaveOps.td
@@ -211,7 +211,7 @@ def AllocateOp : WaveOp<"allocate"> {
 
   let arguments = !con((ins
     Arg<Optional<WaveTensorType>, "Optional parent buffer to view into">:$parent,
-    Arg<WaveDistributedShapeAttr, "Distributed (physical) shape">:$distributed_shape,
+    Arg<WaveExprAttr, "Distributed (physical) shape">:$distributed_shape,
     Arg<OptionalAttr<I64Attr>, "Byte offset into parent buffer">:$offset
   ), commonArguments);
 

--- a/include/water/c/Dialects.h
+++ b/include/water/c/Dialects.h
@@ -85,23 +85,22 @@ mlirWaveAddressSpaceAttrGetValue(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveAddressSpaceAttrGetTypeID();
 
 //===---------------------------------------------------------------------===//
-// WaveDistributedShapeAttr
+// WaveExprAttr
 //===---------------------------------------------------------------------===//
 
-/// Checks whether the given MLIR attribute is a WaveDistributedShapeAttr.
-MLIR_CAPI_EXPORTED bool
-mlirAttributeIsAWaveDistributedShapeAttr(MlirAttribute attr);
+/// Checks whether the given MLIR attribute is a WaveExprAttr.
+MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveExprAttr(MlirAttribute attr);
 
-/// Creates a new WaveDistributedShapeAttr with the given map that is
+/// Creates a new WaveExprAttr with the given map that is
 /// interpreted as accepting the symbols provided in the
 /// `symbolNames` list. The list must have as many entries as maps have symbols,
 /// and all maps must have the same number of symbols and zero dimensions. The
 /// list is expected to only contain WaveSymbolAttr instances.
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirWaveDistributedShapeAttrGet(MlirAttribute *symbolNames, MlirAffineMap map);
+MLIR_CAPI_EXPORTED MlirAttribute mlirWaveExprAttrGet(MlirAttribute *symbolNames,
+                                                     MlirAffineMap map);
 
-/// Returns the typeID of a WaveDistributedShapeAttr.
-MLIR_CAPI_EXPORTED MlirTypeID mlirWaveDistributedShapeAttrGetTypeID();
+/// Returns the typeID of a WaveExprAttr.
+MLIR_CAPI_EXPORTED MlirTypeID mlirWaveExprAttrGetTypeID();
 
 #ifdef __cplusplus
 }

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -119,15 +119,15 @@ MlirTypeID mlirWaveAddressSpaceAttrGetTypeID() {
 }
 
 //===---------------------------------------------------------------------===//
-// WaveDistributedShapeAttr
+// WaveExprAttr
 //===---------------------------------------------------------------------===//
 
-bool mlirAttributeIsAWaveDistributedShapeAttr(MlirAttribute attr) {
-  return llvm::isa<wave::DistributedShapeAttr>(unwrap(attr));
+bool mlirAttributeIsAWaveExprAttr(MlirAttribute attr) {
+  return llvm::isa<wave::ExprAttr>(unwrap(attr));
 }
 
-MlirAttribute mlirWaveDistributedShapeAttrGet(MlirAttribute *symbolNames,
-                                              MlirAffineMap map) {
+MlirAttribute mlirWaveExprAttrGet(MlirAttribute *symbolNames,
+                                  MlirAffineMap map) {
   mlir::MLIRContext *ctx = unwrap(map).getContext();
 
   unsigned numSymbols = mlirAffineMapGetNumSymbols(map);
@@ -137,9 +137,9 @@ MlirAttribute mlirWaveDistributedShapeAttrGet(MlirAttribute *symbolNames,
         return llvm::cast<wave::WaveSymbolAttr>(unwrap(attr));
       });
 
-  return wrap(wave::DistributedShapeAttr::get(ctx, symbolAttrs, unwrap(map)));
+  return wrap(wave::ExprAttr::get(ctx, symbolAttrs, unwrap(map)));
 }
 
-MlirTypeID mlirWaveDistributedShapeAttrGetTypeID() {
-  return wrap(mlir::TypeID::get<wave::DistributedShapeAttr>());
+MlirTypeID mlirWaveExprAttrGetTypeID() {
+  return wrap(mlir::TypeID::get<wave::ExprAttr>());
 }

--- a/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -165,16 +165,15 @@ bool WaveHyperparameterAttr::hasSymbol(StringRef symbolName) const {
 }
 
 //===----------------------------------------------------------------------===//
-// DistributedShapeAttr
+// ExprAttr
 //===----------------------------------------------------------------------===//
 
 std::optional<llvm::SmallVector<int64_t>>
-wave::DistributedShapeAttr::getResolvedShape(
-    wave::WaveHyperparameterAttr hyper) const {
+wave::ExprAttr::getResolvedShape(wave::WaveHyperparameterAttr hyper) const {
   return wave::evaluateMapWithHyperparams(getShape(), getSymbolNames(), hyper);
 }
 
-Attribute DistributedShapeAttr::parse(AsmParser &parser, Type) {
+Attribute ExprAttr::parse(AsmParser &parser, Type) {
   if (parser.parseLess())
     return {};
 
@@ -221,8 +220,9 @@ Attribute DistributedShapeAttr::parse(AsmParser &parser, Type) {
     return {};
 
   if (results.empty()) {
-    parser.emitError(parser.getCurrentLocation(),
-                     "distributed shape must have at least one dimension");
+    parser.emitError(
+        parser.getCurrentLocation(),
+        "wave expression attribute must have at least one dimension");
     return {};
   }
   if (parser.parseGreater())
@@ -235,7 +235,7 @@ Attribute DistributedShapeAttr::parse(AsmParser &parser, Type) {
   return get(parser.getContext(), symbolNameAttrs, shape);
 }
 
-void DistributedShapeAttr::print(mlir::AsmPrinter &printer) const {
+void ExprAttr::print(mlir::AsmPrinter &printer) const {
   // Print symbol names like: [M, K] -> ( ... )
   printer << "<[";
   llvm::SmallVector<llvm::StringRef> names;

--- a/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -426,11 +426,10 @@ static LogicalResult verifyReadWriteBounds(Location loc,
                 "indexed memory tensor";
     }
 
-    // Value type must be WaveDistributedShapeAttr.
-    if (!isa<wave::DistributedShapeAttr>(value.getValue()))
-      return emitError(loc)
-             << "'bounds' values must be WaveDistributedShapeAttr, got "
-             << value.getValue();
+    // Value type must be WaveExprAttr.
+    if (!isa<wave::ExprAttr>(value.getValue()))
+      return emitError(loc) << "'bounds' values must be WaveExprAttr, got "
+                            << value.getValue();
 
     knownSymbolNames.insert(value.getName().strref());
   }

--- a/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
+++ b/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
@@ -140,7 +140,7 @@ buildMask(Location loc, wave::WaveReadWriteBoundsAttr boundsDict,
     StringRef name = orderedSyms[d].getName();
     Attribute a = boundsDict.getMapping().get(name);
     assert(a && "bounds dict missing entry for dimension symbol");
-    auto boundAttr = cast<wave::DistributedShapeAttr>(a);
+    auto boundAttr = cast<wave::ExprAttr>(a);
     // Materialize bounds.
     FailureOr<SmallVector<Value>> boundValsFo = materializeAffine(
         loc, boundAttr.getSymbolNames(), boundAttr.getShape(), rewriter, hyper);

--- a/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -28,7 +28,7 @@ public:
   matchAndRewrite(wave::AllocateOp op, wave::AllocateOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     wave::WaveTensorType resultType = op.getResult().getType();
-    wave::DistributedShapeAttr distributedShape = op.getDistributedShape();
+    wave::ExprAttr distributedShape = op.getDistributedShape();
     auto *typeConverter =
         static_cast<const wave::WaveTypeConverter *>(getTypeConverter());
     Type convertedResultType = typeConverter->convertTensorFromComponents(

--- a/python/WaterExtensionNanobind.cpp
+++ b/python/WaterExtensionNanobind.cpp
@@ -181,12 +181,12 @@ NB_MODULE(_waterDialects, m) {
       .value("Register", wave::WaveAddressSpace::Register);
 
   //===---------------------------------------------------------------------===//
-  // WaveDistributedShapeAttr
+  // WaveExprAttr
   //===---------------------------------------------------------------------===//
 
   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
-      d, "WaveDistributedShapeAttr", mlirAttributeIsAWaveDistributedShapeAttr,
-      mlirWaveDistributedShapeAttrGetTypeID)
+      d, "WaveExprAttr", mlirAttributeIsAWaveExprAttr,
+      mlirWaveExprAttrGetTypeID)
       .def_classmethod(
           "get",
           [](const nb::object &cls, const std::vector<std::string> &symbolNames,
@@ -210,9 +210,8 @@ NB_MODULE(_waterDialects, m) {
             if (mlirAffineMapGetNumDims(map) != 0) {
               throw nb::value_error("Maps should not involve dimensions.");
             }
-            return cls(
-                mlirWaveDistributedShapeAttrGet(symbolAttrs.data(), map));
+            return cls(mlirWaveExprAttrGet(symbolAttrs.data(), map));
           },
           nb::arg("cls"), nb::arg("symbol_names"), nb::arg("map"),
-          "Gets a wave.WaveDistributedShapeAttr from parameters.");
+          "Gets a wave.WaveExprAttr from parameters.");
 }

--- a/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -40,7 +40,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
     // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]] : memref<1x6xf32, #gpu.address_space<workgroup>> to !wave.tensor<[@Y, @Z] of f32, <shared>>
     // CHECK:     "test.foo"(%[[CAST]])
     %0 = wave.allocate
-    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
+    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
     : !wave.tensor<[@Y, @Z] of f32, <shared>>
     "test.foo"(%0) : (!wave.tensor<[@Y, @Z] of f32, <shared>>) -> ()
     return
@@ -158,14 +158,14 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 // CHECK-LABEL: func.func @lower_alloc_view
 func.func @lower_alloc_view() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
   // CHECK: %[[BUFF:.*]] = memref.alloc() : memref<256xi8, #gpu.address_space<workgroup>>
-  %parent = wave.allocate { distributed_shape = #wave.distributed_shape<[] -> (256)> }
+  %parent = wave.allocate { distributed_shape = #wave.expr<[] -> (256)> }
     : !wave.tensor<[@M,@N,@K] of i8, <shared>>
 
   // CHECK: %[[OFF:.*]] = arith.constant 128 : index
   // CHECK: %[[VIEW:.*]] = memref.view %[[BUFF]][%[[OFF]]][]
   // CHECK-SAME: : memref<256xi8, #gpu.address_space<workgroup>> to memref<4x32xbf16, #gpu.address_space<workgroup>>
   %buf = wave.allocate in %parent : !wave.tensor<[@M,@N,@K] of i8, <shared>>
-    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
+    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
   return
   }
@@ -178,7 +178,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, K= 128}>}  {
   // CHECK: memref.alloc() : memref<4x32xbf16, #gpu.address_space<workgroup>>
   %buf = wave.allocate
-    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
+    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
   return
   }
@@ -223,8 +223,8 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
         // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 32)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
         N : [WG1, T1, BLOCK_N] -> (WG1 * BLOCK_N + T1 * 32, 4, 1)
       } { bounds = #wave.read_write_bounds<{
-        M = #wave.distributed_shape<[M] -> (M)>,
-        N = #wave.distributed_shape<[N] -> (N)>}>}
+        M = #wave.expr<[M] -> (M)>,
+        N = #wave.expr<[N] -> (N)>}>}
       : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<4xf16>
       // Bounds for dim 0.
       // CHECK: %[[DIM0_SIZE:.+]] = affine.apply affine_map<() -> (100)>()

--- a/test/Dialect/Wave/ops-invalid.mlir
+++ b/test/Dialect/Wave/ops-invalid.mlir
@@ -143,8 +143,8 @@ func.func @mismatch_shape_write(%lhs: !wave.tensor<[@A, @B] of f32, <register>>,
 
 
 func.func @empty_distributed_shape() {
-  // expected-error @below {{distributed shape must have at least one dimension}}
-  %buf = wave.allocate { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> ()>}
+  // expected-error @below {{wave expression attribute must have at least one dimension}}
+  %buf = wave.allocate { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> ()>}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
 }
 
@@ -152,17 +152,17 @@ func.func @empty_distributed_shape() {
 
 func.func @alloc_offset_no_parent() {
   // expected-error @below {{expects parent and offset to be present simultaneously}}
-  %buf = wave.allocate { distributed_shape = #wave.distributed_shape<[] -> (42)>, offset = 42}
+  %buf = wave.allocate { distributed_shape = #wave.expr<[] -> (42)>, offset = 42}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
 }
 
 // -----
 
 func.func @alloc_parent_no_offset() {
-  %alloc = wave.allocate { distributed_shape = #wave.distributed_shape<[] -> (100)> }
+  %alloc = wave.allocate { distributed_shape = #wave.expr<[] -> (100)> }
     : !wave.tensor<[@M, @K] of bf16, <shared>>
   // expected-error @below {{expects parent and offset to be present simultaneously}}
-  %buf = wave.allocate in %alloc : !wave.tensor<[@M, @K] of bf16, <shared>> { distributed_shape = #wave.distributed_shape<[] -> (42)>}
+  %buf = wave.allocate in %alloc : !wave.tensor<[@M, @K] of bf16, <shared>> { distributed_shape = #wave.expr<[] -> (42)>}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
 }
 
@@ -253,7 +253,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 
 func.func @bounds_missing_dim(%mem: !wave.tensor<[@M, @N] of f32>, %val: !wave.tensor<[@M, @N] of f32, <register>>) {
   // expected-error @below {{bounds not provided for memory tensor symbol 'N'}}
-  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.distributed_shape<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
+  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.expr<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
   return
 }
 
@@ -261,14 +261,14 @@ func.func @bounds_missing_dim(%mem: !wave.tensor<[@M, @N] of f32>, %val: !wave.t
 
 func.func @bounds_extraneous_dim(%mem: !wave.tensor<[@N] of f32>, %val: !wave.tensor<[@N] of f32, <register>>) {
   // expected-error @below {{'bounds' specified for a symbol "M" not used in the indexed memory tensor}}
-  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.distributed_shape<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@N] of f32, <register>>, !wave.tensor<[@N] of f32>
+  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.expr<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@N] of f32, <register>>, !wave.tensor<[@N] of f32>
   return
 }
 
 // -----
 
 func.func @bounds_wrong_type(%mem: !wave.tensor<[@N] of f32>) {
-  // expected-error @below {{'bounds' values must be WaveDistributedShapeAttr, got 42 : i64}}
+  // expected-error @below {{'bounds' values must be WaveExprAttr, got 42 : i64}}
   wave.read %mem { bounds = #wave.read_write_bounds<{ N = 42 }> } : (!wave.tensor<[@N] of f32>) -> !wave.tensor<[@N] of f32, <register>>
   return
 }

--- a/test/Dialect/Wave/ops.mlir
+++ b/test/Dialect/Wave/ops.mlir
@@ -121,11 +121,11 @@ func.func @register_with_hyperparameter() attributes {hyperparameters = #wave.hy
 // CHECK-LABEL: @allocate
 func.func @allocate() -> !wave.tensor<[@M, @N] of bf16, <shared>> {
   // CHECK: wave.allocate
-  %parent = wave.allocate { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
+  %parent = wave.allocate { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
     : !wave.tensor<[@M, @N] of bf16, <shared>>
 
   %buf = wave.allocate in %parent : !wave.tensor<[@M, @N] of bf16, <shared>>
-    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 64}
+    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 64}
     : !wave.tensor<[@M, @N] of bf16, <shared>>
 
   return %buf : !wave.tensor<[@M, @N] of bf16, <shared>>
@@ -148,6 +148,6 @@ attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 32, BLOCK_N 
 // CHECK-LABEL: @write_with_bounds
 func.func @write_with_bounds(%memo: !wave.tensor<[@M] of f32>, %val: !wave.tensor<[@M] of f32, <register>>) {
   // CHECK:       wave.read_write_bounds
-  wave.write %val, %memo { bounds = #wave.read_write_bounds<{ M = #wave.distributed_shape<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@M] of f32, <register>>, !wave.tensor<[@M] of f32>
+  wave.write %val, %memo { bounds = #wave.read_write_bounds<{ M = #wave.expr<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@M] of f32, <register>>, !wave.tensor<[@M] of f32>
   return
 }

--- a/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -124,12 +124,12 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // CHECK-LABEL: func.func @alloc_is_harmless
 func.func @alloc_is_harmless() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
   // CHECK: wave.allocate
-  %parent = wave.allocate { distributed_shape = #wave.distributed_shape<[] -> (256)> }
+  %parent = wave.allocate { distributed_shape = #wave.expr<[] -> (256)> }
     : !wave.tensor<[@M,@N,@K] of i8, <shared>>
 
   // CHECK: wave.allocate
   %buf = wave.allocate in %parent : !wave.tensor<[@M,@N,@K] of i8, <shared>>
-    { distributed_shape = #wave.distributed_shape<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
+    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
     : !wave.tensor<[@M, @K] of bf16, <shared>>
   return
   }

--- a/test/Dialect/Wave/python_bindings.py
+++ b/test/Dialect/Wave/python_bindings.py
@@ -95,11 +95,11 @@ try:
         else:
             assert False, "Expected to fail with TypeError."
 
-        # CHECK: #wave.distributed_shape<[$WG0, BLOCK_M, $T0] -> ($WG0 * 3)>
-        print(wave.WaveDistributedShapeAttr.get(symbol_names, start_map))
+        # CHECK: #wave.expr<[$WG0, BLOCK_M, $T0] -> ($WG0 * 3)>
+        print(wave.WaveExprAttr.get(symbol_names, start_map))
 
         try:
-            wave.WaveDistributedShapeAttr.get(symbol_names[:-1], start_map)
+            wave.WaveExprAttr.get(symbol_names[:-1], start_map)
         except ValueError as e:
             assert "as many entries as map have symbols" in str(e)
         else:


### PR DESCRIPTION
This PR renames the attribute "DistributedShapeAttr" to "ShapeExprAttr". This generalizes the attribute to cover both read/write bounds and distributed shapes in allocate.