### PR TITLE
[Dialect] Introduce special attributes for block/thread/register symbols 

### DIFF
--- a/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -293,7 +293,26 @@ def DeviceConstraintAttr : AttrDef<WaveDialect, "DeviceConstraint"> {
 // Other attributes
 //-----------------------------------------------------------------------------
 
-def WaveSymbolAttr : AttrDef<WaveDialect, "WaveSymbol"> {
+def WaveIndexSymbolEnum
+    : I32EnumAttr<"WaveIndexSymbol", "Index symbol", [
+  I32EnumAttrCase<"DEVICE_DIM_0", 0, "DD0">,
+  I32EnumAttrCase<"DEVICE_DIM_1", 1, "DD1">,
+  I32EnumAttrCase<"DEVICE_DIM_2", 2, "DD2">,
+  I32EnumAttrCase<"WORKGROUP_0", 3, "WG0">,
+  I32EnumAttrCase<"WORKGROUP_1", 4, "WG1">,
+  I32EnumAttrCase<"WORKGROUP_2", 5, "WG2">,
+  I32EnumAttrCase<"THREAD_0", 6, "T0">,
+  I32EnumAttrCase<"THREAD_1", 7, "T1">,
+  I32EnumAttrCase<"THREAD_2", 8, "T2">,
+  I32EnumAttrCase<"GPR_NUMBER", 9, "GPR_NUM">,
+  I32EnumAttrCase<"NON_INDEX", 10, "NON_IDX">,
+]> {
+  let cppNamespace = "::wave";
+  let genSpecializedAttr = 0;
+}
+
+def WaveSymbolAttr
+    : AttrDef<WaveDialect, "WaveSymbol"> {
   let mnemonic = "symbol";
   let description = [{
     Base symbol used in symbolic expressions in the Wave dialect. This is
@@ -303,12 +322,14 @@ def WaveSymbolAttr : AttrDef<WaveDialect, "WaveSymbol"> {
     programs. Wave expression symbols are not part of the symbol table.
   }];
 
-  let parameters = (ins StringRefParameter<"name of the symbol">:$name);
-  let assemblyFormat = "`<` $name `>`";
+  let parameters = (ins EnumParameter<WaveIndexSymbolEnum>:$kind,
+                        StringRefParameter<"name of the symbol">:$name);
+
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
-    void printAsSymbolRef(::llvm::raw_ostream &os) const {
-      os << "@" << getName();
+    bool isIndexSymbol() const {
+      return getKind() != ::wave::WaveIndexSymbol::NON_INDEX;
     }
   }];
 }
@@ -320,7 +341,7 @@ def WaveExpressionAttr : AttrDef<WaveDialect, "WaveExpression"> {
     Base symbolic expression used in the Wave dialect.
   }];
 
-  let parameters = (ins ArrayRefParameter<"WaveSymbolAttr">:$symbol_names,
+  let parameters = (ins ArrayRefParameter<"WaveSymbolAttr">:$symbols,
                     "::mlir::AffineMap":$map);
 
   let hasCustomAssemblyFormat = 1;
@@ -328,15 +349,15 @@ def WaveExpressionAttr : AttrDef<WaveDialect, "WaveExpression"> {
   let extraClassDeclaration = [{
     /// Get the symbol name at the given index.
     ::llvm::StringRef getSymbolName(unsigned index) const {
-      auto names = getSymbolNames();
-      if (index >= names.size()) return ::llvm::StringRef();
-        return names[index].getName();
+      auto symbols = getSymbols();
+      if (index >= symbols.size()) return ::llvm::StringRef();
+        return symbols[index].getName();
     }
 
     /// Get all symbol names as a vector of string references.
     ::llvm::SmallVector<::llvm::StringRef> getAllSymbolNames() const {
-      auto names = getSymbolNames();
-      return ::llvm::map_to_vector(names, [](::wave::WaveSymbolAttr attr) {
+      auto symbols = getSymbols();
+      return ::llvm::map_to_vector(symbols, [](::wave::WaveSymbolAttr attr) {
         return attr.getName();
       });
     }
@@ -351,15 +372,15 @@ def WaveIndexMappingAttr : AttrDef<WaveDialect, "WaveIndexMapping"> {
 
     This attribute preserves meaningful symbol names (e.g., WG0, BLOCK_M, T0)
     while storing affine maps internally for start, step, and stride. The
-    symbol_names array corresponds 1:1 to the symbols in the affine
-    expressions, where s0 maps to symbol_names[0], s1 to symbol_names[1], etc.
+    symbols array corresponds 1:1 to the symbols in the affine
+    expressions, where s0 maps to symbols[0], s1 to symbols[1], etc.
 
-    Custom syntax: [symbol_names] -> (start_expr, step_expr, stride_expr)
+    Custom syntax: [symbols] -> (start_expr, step_expr, stride_expr)
     Example: [WG0, BLOCK_M] -> (WG0 * BLOCK_M + 42, 1, BLOCK_M)
   }];
 
   let parameters = (ins
-    ArrayRefParameter<"WaveSymbolAttr">:$symbol_names,
+    ArrayRefParameter<"WaveSymbolAttr">:$symbols,
     "::mlir::AffineMap":$start,
     "::mlir::AffineMap":$step,
     "::mlir::AffineMap":$stride
@@ -370,17 +391,17 @@ def WaveIndexMappingAttr : AttrDef<WaveDialect, "WaveIndexMapping"> {
   let extraClassDeclaration = [{
     /// Get the symbol name at the given index.
     ::llvm::StringRef getSymbolName(unsigned index) {
-      auto names = getSymbolNames();
-      if (index >= names.size()) return ::llvm::StringRef();
-      return names[index].getName();
+      auto symbols = getSymbols();
+      if (index >= symbols.size()) return ::llvm::StringRef();
+      return symbols[index].getName();
     }
 
     /// Get all symbol names as a vector of string references.
     ::llvm::SmallVector<::llvm::StringRef> getAllSymbolNames() const {
       ::llvm::SmallVector<::llvm::StringRef> result;
-      auto names = getSymbolNames();
-      result.reserve(names.size());
-      for (auto symbolAttr : names) {
+      auto symbols = getSymbols();
+      result.reserve(symbols.size());
+      for (auto symbolAttr : symbols) {
         result.push_back(symbolAttr.getName());
       }
       return result;
@@ -426,7 +447,7 @@ def WaveExprAttr : AttrDef<WaveDialect, "Expr"> {
     • Distributed (physical) shapes for allocations
 
     Stores:
-      - symbol_names: [WaveSymbolAttr] giving names (e.g., M, BLOCK_M, BLOCK_K)
+      - symbols: [WaveSymbolAttr] giving names (e.g., M, BLOCK_M, BLOCK_K)
       The i-th name maps to the s<i> in the affine expressions
       - shape: affine_map<()[s0..sN] -> (expr_0, ..., expr_{rank-1})>
       Each result expr_k defines the k-th physical dimension.
@@ -436,7 +457,7 @@ def WaveExprAttr : AttrDef<WaveDialect, "Expr"> {
   }];
 
   let parameters = (ins
-    ArrayRefParameter<"WaveSymbolAttr">:$symbol_names,
+    ArrayRefParameter<"WaveSymbolAttr">:$symbols,
     "::mlir::AffineMap":$shape
   );
   let hasCustomAssemblyFormat = 1;
@@ -447,6 +468,17 @@ def WaveExprAttr : AttrDef<WaveDialect, "Expr"> {
 
     std::optional<llvm::SmallVector<int64_t>>
     getResolvedShape(::wave::WaveHyperparameterAttr hyper) const;
+
+    /// Get all symbol names as a vector of string references.
+    ::llvm::SmallVector<::llvm::StringRef> getAllSymbolNames() const {
+      ::llvm::SmallVector<::llvm::StringRef> result;
+      auto symbols = getSymbols();
+      result.reserve(symbols.size());
+      for (auto symbolAttr : symbols) {
+        result.push_back(symbolAttr.getName());
+      }
+      return result;
+    }
   }];
 }
 

--- a/include/water/c/Dialects.h
+++ b/include/water/c/Dialects.h
@@ -23,8 +23,8 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Wave, wave);
 MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveSymbolAttr(MlirAttribute attr);
 
 /// Creates a new WaveSymbolAttr with the given symbol name.
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirWaveSymbolAttrGet(MlirContext mlirCtx, MlirStringRef symbolName);
+MLIR_CAPI_EXPORTED MlirAttribute mlirWaveSymbolAttrGet(
+    MlirContext mlirCtx, unsigned kind, MlirStringRef symbolName);
 
 /// Returns the typeID of a WaveSymbolAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveSymbolAttrGetTypeID();

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -23,11 +23,13 @@ bool mlirAttributeIsAWaveSymbolAttr(MlirAttribute attr) {
   return llvm::isa<wave::WaveSymbolAttr>(unwrap(attr));
 }
 
-MlirAttribute mlirWaveSymbolAttrGet(MlirContext mlirCtx,
+MlirAttribute mlirWaveSymbolAttrGet(MlirContext mlirCtx, unsigned kind,
                                     MlirStringRef symbolNameStrRef) {
   mlir::MLIRContext *ctx = unwrap(mlirCtx);
+
   llvm::StringRef symbolName = unwrap(symbolNameStrRef);
-  return wrap(wave::WaveSymbolAttr::get(ctx, symbolName));
+  return wrap(wave::WaveSymbolAttr::get(
+      ctx, static_cast<wave::WaveIndexSymbol>(kind), symbolName));
 }
 
 MlirTypeID mlirWaveSymbolAttrGetTypeID() {

--- a/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -113,16 +113,12 @@ static llvm::LogicalResult verifyAttributeHyperparamUses(
     }
   }
 
-  // TODO: somehow get rid of these hardcoded magic names.
-  static llvm::SmallVector<llvm::StringRef> fixmeMagicNames = {
-      "_T0", "_T1", "_T2", "_WG0", "_WG1", "_WG2"};
-
   mlir::WalkResult walkResult =
       namedAttr.getValue().walk([&](wave::WaveSymbolAttr symbolAttr) {
         usedSymbols.insert(symbolAttr.getName());
 
-        if (hyperparam.getMapping().contains(symbolAttr.getName()) ||
-            llvm::is_contained(fixmeMagicNames, symbolAttr.getName()))
+        if (symbolAttr.isIndexSymbol() ||
+            hyperparam.getMapping().contains(symbolAttr.getName()))
           return mlir::WalkResult::advance();
 
         mlir::InFlightDiagnostic diag = emitError()
@@ -188,9 +184,9 @@ verifyConstraints(mlir::ArrayAttr constraints,
   // * The number of devices should be greater than or equal to one.
   for (auto &&[symbol, constraint] : deviceConstraints) {
     std::optional<llvm::SmallVector<int64_t>> evaluated =
-        wave::evaluateMapWithHyperparams(
-            constraint.getTileSize().getMap(),
-            constraint.getTileSize().getSymbolNames(), hyperparams);
+        wave::evaluateMapWithHyperparams(constraint.getTileSize().getMap(),
+                                         constraint.getTileSize().getSymbols(),
+                                         hyperparams);
     assert(evaluated &&
            "failed to evaluate wave expression for device constraint");
     assert(evaluated->size() == 1 &&
@@ -236,9 +232,9 @@ verifyConstraints(mlir::ArrayAttr constraints,
     }
 
     std::optional<llvm::SmallVector<int64_t>> evaluated =
-        wave::evaluateMapWithHyperparams(
-            constraint.getTileSize().getMap(),
-            constraint.getTileSize().getSymbolNames(), hyperparams);
+        wave::evaluateMapWithHyperparams(constraint.getTileSize().getMap(),
+                                         constraint.getTileSize().getSymbols(),
+                                         hyperparams);
     assert(evaluated &&
            "failed to evaluate wave expression for workgroup constraint");
     assert(evaluated->size() == 1 &&
@@ -281,9 +277,9 @@ verifyConstraints(mlir::ArrayAttr constraints,
     }
 
     std::optional<llvm::SmallVector<int64_t>> evaluated =
-        wave::evaluateMapWithHyperparams(
-            constraint.getTileSize().getMap(),
-            constraint.getTileSize().getSymbolNames(), hyperparams);
+        wave::evaluateMapWithHyperparams(constraint.getTileSize().getMap(),
+                                         constraint.getTileSize().getSymbols(),
+                                         hyperparams);
     assert(evaluated &&
            "failed to evaluate wave expression for wave constraint");
     assert(evaluated->size() == 1 &&
@@ -301,9 +297,9 @@ verifyConstraints(mlir::ArrayAttr constraints,
   // * The number of tiles should be greater than or equal to one.
   for (auto &&[symbol, constraint] : tilingConstraints) {
     std::optional<llvm::SmallVector<int64_t>> evaluated =
-        wave::evaluateMapWithHyperparams(
-            constraint.getTileSize().getMap(),
-            constraint.getTileSize().getSymbolNames(), hyperparams);
+        wave::evaluateMapWithHyperparams(constraint.getTileSize().getMap(),
+                                         constraint.getTileSize().getSymbols(),
+                                         hyperparams);
     assert(evaluated &&
            "failed to evaluate wave expression for tiling constraint");
     assert(evaluated->size() == 1 &&

--- a/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -67,19 +67,16 @@ static void printRegisterOpTypes(mlir::OpAsmPrinter &printer, mlir::Operation *,
 // Parse an @-symbol and interpret it as a wave symbol.
 static mlir::ParseResult parseSingleSymbol(mlir::OpAsmParser &parser,
                                            wave::WaveSymbolAttr &symbolAttr) {
-  mlir::StringAttr strAttr;
-  if (mlir::failed(parser.parseSymbolName(strAttr)))
-    return mlir::failure();
+  if (parser.parseCustomAttributeWithFallback(symbolAttr))
+    return {};
 
-  symbolAttr =
-      wave::WaveSymbolAttr::get(parser.getContext(), strAttr.getValue());
   return mlir::success();
 }
 
 // Print a wave symbol as an MLIR @-symbol.
 static void printSingleSymbol(mlir::OpAsmPrinter &printer, mlir::Operation *,
                               wave::WaveSymbolAttr symbolAttr) {
-  printer.printSymbolName(symbolAttr.getName());
+  symbolAttr.print(printer);
 }
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/Wave/IR/WaveTypes.cpp
+++ b/lib/Dialect/Wave/IR/WaveTypes.cpp
@@ -28,11 +28,10 @@ parseTensorShape(mlir::AsmParser &parser,
 
   fullySpecified = true;
   auto parseOne = [&]() -> mlir::ParseResult {
-    mlir::StringAttr stringAttr;
-    if (parser.parseSymbolName(stringAttr).failed())
-      return mlir::failure();
-    attr.emplace_back(wave::WaveSymbolAttr::get(stringAttr.getContext(),
-                                                stringAttr.getValue()));
+    wave::WaveSymbolAttr symbolAttr;
+    if (parser.parseCustomAttributeWithFallback(symbolAttr))
+      return {};
+    attr.emplace_back(symbolAttr);
     return mlir::success();
   };
 
@@ -48,9 +47,7 @@ static void printTensorShape(mlir::AsmPrinter &printer,
     return;
   }
 
-  auto printOne = [&](wave::WaveSymbolAttr attr) {
-    attr.printAsSymbolRef(printer.getStream());
-  };
+  auto printOne = [&](wave::WaveSymbolAttr attr) { attr.print(printer); };
 
   printer.getStream() << "[";
   llvm::interleaveComma(shape, printer.getStream(), printOne);

--- a/lib/Dialect/Wave/IR/WaveUtils.cpp
+++ b/lib/Dialect/Wave/IR/WaveUtils.cpp
@@ -25,7 +25,7 @@ wave::getUncollapsedVectorShape(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
     auto mapAttr = cast<wave::WaveIndexMappingAttr>(entry);
     std::optional<SmallVector<int64_t>> folded =
         wave::evaluateMapWithHyperparams(mapAttr.getStep(),
-                                         mapAttr.getSymbolNames(), hyper);
+                                         mapAttr.getSymbols(), hyper);
     if (!folded)
       return ShapedType::kDynamic;
     assert(folded->size() == 1 && "expected single-result map");

--- a/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -32,7 +32,7 @@ public:
     auto *typeConverter =
         static_cast<const wave::WaveTypeConverter *>(getTypeConverter());
     Type convertedResultType = typeConverter->convertTensorFromComponents(
-        distributedShape.getSymbolNames(), distributedShape.getShape(),
+        distributedShape.getSymbols(), distributedShape.getShape(),
         resultType.getElementType(), resultType.getAddressSpaceValue());
     if (!convertedResultType) {
       return rewriter.notifyMatchFailure(op,

--- a/test/Dialect/Wave/attr-constraint-invalid.mlir
+++ b/test/Dialect/Wave/attr-constraint-invalid.mlir
@@ -19,193 +19,193 @@ func.func private @test_num_dimensions_mismatch2() attributes { wave.constraints
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, K = 1024, BLOCK_M = 128, BLOCK_K = 128}>
-#wg_constraint1 = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-#wg_constraint2 = #wave.workgroup_constraint<dim = <"K">, tile_size = [BLOCK_K] -> (BLOCK_K), workgroup_dim = <x>>
-// expected-error @below {{the dimension of the workgroup constraint in wg_constraint: #wave.symbol<"K"> should match the dimension of the wave constraint: #wave.symbol<"M">}}
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4),
+#wg_constraint1 = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+#wg_constraint2 = #wave.workgroup_constraint<dim = <K>, tile_size = [<BLOCK_K>] -> (BLOCK_K), workgroup_dim = <x>>
+// expected-error @below {{the dimension of the workgroup constraint in wg_constraint: #wave.symbol<K> should match the dimension of the wave constraint: #wave.symbol<M>}}
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4),
                                        wg_constraint = #wg_constraint2>
 func.func private @test_wrong_wg_attr() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint1, #wg_constraint2, #wv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, K = 1024, BLOCK_M = 128, BLOCK_K = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"K">, tile_size = [BLOCK_K] -> (BLOCK_K), workgroup_dim = <x>>
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-// expected-error @below {{missing corresponding workgroup constraint for dimension: #wave.symbol<"M">}}
+#wg_constraint = #wave.workgroup_constraint<dim = <K>, tile_size = [<BLOCK_K>] -> (BLOCK_K), workgroup_dim = <x>>
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+// expected-error @below {{missing corresponding workgroup constraint for dimension: #wave.symbol<M>}}
 func.func private @test_wrong_wg_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint, #wv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-// expected-error @below {{missing corresponding workgroup constraint for dimension: #wave.symbol<"M">}}
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+// expected-error @below {{missing corresponding workgroup constraint for dimension: #wave.symbol<M>}}
 func.func private @test_missing_wg_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>, primary=false>
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>, primary=false>
 // expected-error @below {{missing primary workgroup constraint for workgroup dimension: #wave.workgroup_dim<x>}}
 func.func private @test_no_primary_wg_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{K = 512, M = 1024, BLOCK_K = 64, BLOCK_M = 128}>
-#wg_constraint1 = #wave.workgroup_constraint<dim = <"K">, tile_size = [BLOCK_K] -> (BLOCK_K), workgroup_dim = <x>>
-#wg_constraint2 = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
+#wg_constraint1 = #wave.workgroup_constraint<dim = <K>, tile_size = [<BLOCK_K>] -> (BLOCK_K), workgroup_dim = <x>>
+#wg_constraint2 = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
 // expected-error @below {{workgroup dimension #wave.workgroup_dim<x> has more than one primary workgroup constraint}}
 func.func private @test_duplicate_primary_wg_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint1, #wg_constraint2] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, DEVICE_M = 2048}>
-#dv_constraint = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
-// expected-error @below {{invalid number of devices: 0 for dimension: #wave.symbol<"M">}}
+#dv_constraint = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
+// expected-error @below {{invalid number of devices: 0 for dimension: #wave.symbol<M>}}
 func.func private @test_wrong_device_size() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#dv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 2048}>
-#constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-// expected-error @below {{invalid number of workgroups: 0 for dimension: #wave.symbol<"M">}}
+#constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+// expected-error @below {{invalid number of workgroups: 0 for dimension: #wave.symbol<M>}}
 func.func private @test_wrong_wg_size() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M)>
-// expected-error @below {{invalid number of waves: 0 for dimension: #wave.symbol<"M">}}
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M)>
+// expected-error @below {{invalid number of waves: 0 for dimension: #wave.symbol<M>}}
 func.func private @test_wrong_wave_size() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint, #wv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 2048}>
-#constraint = #wave.tiling_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M)>
-// expected-error @below {{invalid number of tiles: 0 for dimension: #wave.symbol<"M">}}
+#constraint = #wave.tiling_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M)>
+// expected-error @below {{invalid number of tiles: 0 for dimension: #wave.symbol<M>}}
 func.func private @test_wrong_tile_size() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, DEVICE_M = 128}>
-#dv_constraint1 = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
-#dv_constraint2 = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M floordiv 4), device_dim = 0>
-// expected-error @below {{more than one device constraint for dimension: #wave.symbol<"M">}}
+#dv_constraint1 = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
+#dv_constraint2 = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M floordiv 4), device_dim = 0>
+// expected-error @below {{more than one device constraint for dimension: #wave.symbol<M>}}
 func.func private @test_duplicate_device_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#dv_constraint1, #dv_constraint2] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
-#wg_constraint1 = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
-#wg_constraint2 = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 2), workgroup_dim = <x>>
-// expected-error @below {{more than one workgroup constraint for dimension: #wave.symbol<"M">}}
+#wg_constraint1 = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
+#wg_constraint2 = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 2), workgroup_dim = <x>>
+// expected-error @below {{more than one workgroup constraint for dimension: #wave.symbol<M>}}
 func.func private @test_duplicate_wg_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint1, #wg_constraint2] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-#wv_constraint1 = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-#wv_constraint2 = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 2)>
-// expected-error @below {{more than one wave constraint for dimension: #wave.symbol<"M">}}
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+#wv_constraint1 = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+#wv_constraint2 = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 2)>
+// expected-error @below {{more than one wave constraint for dimension: #wave.symbol<M>}}
 func.func private @test_duplicate_wave_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint, #wv_constraint1, #wv_constraint2] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
-#tl_constraint1 = #wave.tiling_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M)>
-#tl_constraint2 = #wave.tiling_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-// expected-error @below {{more than one tiling constraint for dimension: #wave.symbol<"M">}}
+#tl_constraint1 = #wave.tiling_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M)>
+#tl_constraint2 = #wave.tiling_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+// expected-error @below {{more than one tiling constraint for dimension: #wave.symbol<M>}}
 func.func private @test_duplicate_tile_dim() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#tl_constraint1, #tl_constraint2] }
 
 // -----
 
-#dv_constraint = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
+#dv_constraint = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
 // expected-error @below {{missing hyperparameters attribute}}
 func.func private @test_dev_missing_hyperparams1() attributes { wave.constraints = [#dv_constraint] }
 
 // -----
 
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
 // expected-error @below {{missing hyperparameters attribute}}
 func.func private @test_wg_missing_hyperparams1() attributes { wave.constraints = [#wg_constraint] }
 
 // -----
 
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
 // expected-error @below {{missing hyperparameters attribute}}
 func.func private @test_wave_missing_hyperparams1() attributes { wave.constraints = [#wg_constraint, #wv_constraint] }
 
 // -----
 
-#tl_constraint = #wave.tiling_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M)>
+#tl_constraint = #wave.tiling_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M)>
 // expected-error @below {{missing hyperparameters attribute}}
 func.func private @test_tile_missing_hyperparams1() attributes { wave.constraints = [#tl_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{K = 1024, BLOCK_K = 128}>
-#dv_constraint = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
-// expected-error @below {{uses symbolic value #wave.symbol<"M"> not provided as a hyperparameter}}
+#dv_constraint = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
+// expected-error @below {{uses symbolic value #wave.symbol<M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, K}}
 func.func private @test_dev_missing_hyperparams2() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#dv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{K = 1024, BLOCK_K = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
-// expected-error @below {{uses symbolic value #wave.symbol<"M"> not provided as a hyperparameter}}
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
+// expected-error @below {{uses symbolic value #wave.symbol<M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, K}}
 func.func private @test_wg_missing_hyperparams2() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{K = 1024, BLOCK_K = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_K] -> (BLOCK_K), workgroup_dim = <x>>
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-// expected-error @below {{uses symbolic value #wave.symbol<"M"> not provided as a hyperparameter}}
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_K>] -> (BLOCK_K), workgroup_dim = <x>>
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+// expected-error @below {{uses symbolic value #wave.symbol<M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, K}}
 func.func private @test_wave_missing_hyperparams2() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint, #wv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{K = 1024, BLOCK_K = 128}>
-#tl_constraint = #wave.tiling_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M)>
-// expected-error @below {{uses symbolic value #wave.symbol<"M"> not provided as a hyperparameter}}
+#tl_constraint = #wave.tiling_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M)>
+// expected-error @below {{uses symbolic value #wave.symbol<M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, K}}
 func.func private @test_tile_missing_hyperparams2() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#tl_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_K = 128}>
-#dv_constraint = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
-// expected-error @below {{uses symbolic value #wave.symbol<"DEVICE_M"> not provided as a hyperparameter}}
+#dv_constraint = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
+// expected-error @below {{uses symbolic value #wave.symbol<DEVICE_M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, M}}
 func.func private @test_dev_missing_hyperparams3() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#dv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_K = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
-// expected-error @below {{uses symbolic value #wave.symbol<"BLOCK_M"> not provided as a hyperparameter}}
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4), workgroup_dim = <x>>
+// expected-error @below {{uses symbolic value #wave.symbol<BLOCK_M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, M}}
 func.func private @test_wg_missing_hyperparams3() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_K = 128}>
-#wg_constraint = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_K] -> (BLOCK_K), workgroup_dim = <x>>
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-// expected-error @below {{uses symbolic value #wave.symbol<"BLOCK_M"> not provided as a hyperparameter}}
+#wg_constraint = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_K>] -> (BLOCK_K), workgroup_dim = <x>>
+#wv_constraint = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+// expected-error @below {{uses symbolic value #wave.symbol<BLOCK_M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, M}}
 func.func private @test_wave_missing_hyperparams3() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint, #wv_constraint] }
 
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_K = 128}>
-#tl_constraint = #wave.tiling_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M)>
-// expected-error @below {{uses symbolic value #wave.symbol<"BLOCK_M"> not provided as a hyperparameter}}
+#tl_constraint = #wave.tiling_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M)>
+// expected-error @below {{uses symbolic value #wave.symbol<BLOCK_M> not provided as a hyperparameter}}
 // expected-note @below {{available symbols: BLOCK_K, M}}
 func.func private @test_tile_missing_hyperparams3() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#tl_constraint] }
 

--- a/test/Dialect/Wave/attr-constraint.mlir
+++ b/test/Dialect/Wave/attr-constraint.mlir
@@ -18,54 +18,54 @@ func.func private @test_hw2() attributes { wave.hyperparameters = #wave.hyperpar
 
 
 // CHECK-LABEL: @test_wg1
-// CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-#wg_constraint1 = #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
+// CHECK: #wave.workgroup_constraint<dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+#wg_constraint1 = #wave.workgroup_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
 #wg_hyperparams1 = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
 func.func private @test_wg1() attributes { wave.hyperparameters = #wg_hyperparams1, wave.constraints = [#wg_constraint1] }
 
 // CHECK-LABEL: @test_wg2
-// CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-#wg_constraint2 = #wave.workgroup_constraint<dim = <"M">,
-                                             tile_size = [BLOCK_M] -> (BLOCK_M),
+// CHECK: #wave.workgroup_constraint<dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+#wg_constraint2 = #wave.workgroup_constraint<dim = <M>,
+                                             tile_size = [<BLOCK_M>] -> (BLOCK_M),
                                              workgroup_dim = <x>,
                                              primary = true>
 func.func private @test_wg2() attributes { wave.hyperparameters = #wg_hyperparams1, wave.constraints = [#wg_constraint2] }
 
 // CHECK-LABEL: @test_wg3
-// CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-// CHECK: #wave.workgroup_constraint<dim = <"N">, tile_size = [BLOCK_N] -> (BLOCK_N), workgroup_dim = <y>>
-#wg_constraint3 = #wave.workgroup_constraint<dim = <"N">, tile_size = [BLOCK_N] -> (BLOCK_N), workgroup_dim = <y>>
+// CHECK: #wave.workgroup_constraint<dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+// CHECK: #wave.workgroup_constraint<dim = <N>, tile_size = [#wave.symbol<BLOCK_N>] -> (BLOCK_N), workgroup_dim = <y>>
+#wg_constraint3 = #wave.workgroup_constraint<dim = <N>, tile_size = [<BLOCK_N>] -> (BLOCK_N), workgroup_dim = <y>>
 #wg_hyperparams3 = #wave.hyperparameters<{M = 1024,N = 1024, BLOCK_M = 128, BLOCK_N = 128}>
 func.func private @test_wg3() attributes { wave.hyperparameters = #wg_hyperparams3, wave.constraints = [#wg_constraint2, #wg_constraint3] }
 
 // CHECK-LABEL: @test_wg4
-// CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>,
-// CHECKL #wave.workgroup_constraint<dim = <"N">, tile_size = [BLOCK_N] -> (BLOCK_N), workgroup_dim = <x>, primary = false>
-#wg_constraint4 = #wave.workgroup_constraint<dim = <"N">, tile_size = [BLOCK_N] -> (BLOCK_N), workgroup_dim = <x>, primary=false>
+// CHECK: #wave.workgroup_constraint<dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>,
+// CHECKL #wave.workgroup_constraint<dim = <N>, tile_size = [#wave.symbol<BLOCK_N>] -> (BLOCK_N), workgroup_dim = <x>, primary = false>
+#wg_constraint4 = #wave.workgroup_constraint<dim = <N>, tile_size = [<BLOCK_N>] -> (BLOCK_N), workgroup_dim = <x>, primary=false>
 func.func private @test_wg4() attributes { wave.hyperparameters = #wg_hyperparams3, wave.constraints = [#wg_constraint2, #wg_constraint4] }
 
 // CHECK-LABEL: @test_tiling
-// CHECK: #wave.tiling_constraint<dim = <"K">, tile_size = [BLOCK_K] -> (BLOCK_K)>
-#tl_constraint = #wave.tiling_constraint<dim = <"K">, tile_size = [BLOCK_K] -> (BLOCK_K)>
+// CHECK: #wave.tiling_constraint<dim = <K>, tile_size = [#wave.symbol<BLOCK_K>] -> (BLOCK_K)>
+#tl_constraint = #wave.tiling_constraint<dim = <K>, tile_size = [<BLOCK_K>] -> (BLOCK_K)>
 #tl_hyperparams = #wave.hyperparameters<{K = 1024, BLOCK_K = 128}>
 func.func private @test_tiling() attributes { wave.hyperparameters = #tl_hyperparams, wave.constraints = [#tl_constraint] }
 
 // CHECK-LABEL: @test_wave1
-// CHECK: #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
-#wv_constraint1 = #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4)>
+// CHECK: #wave.wave_constraint<dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M floordiv 4)>
+#wv_constraint1 = #wave.wave_constraint<dim = <M>, tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4)>
 #wv_hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
 func.func private @test_wave1() attributes { wave.hyperparameters = #wv_hyperparams, wave.constraints = [#wg_constraint1, #wv_constraint1] }
 
 // CHECK-LABEL: @test_wave2
-// CHECK: #wave.wave_constraint<dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4),
-// CHECK:   wg_constraint = <dim = <"M">, tile_size = [BLOCK_M] -> (BLOCK_M), workgroup_dim = <x>>
-#wv_constraint2 = #wave.wave_constraint<dim = <"M">,
-                                        tile_size = [BLOCK_M] -> (BLOCK_M floordiv 4),
+// CHECK: #wave.wave_constraint<dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M floordiv 4),
+// CHECK:   wg_constraint = <dim = <M>, tile_size = [#wave.symbol<BLOCK_M>] -> (BLOCK_M), workgroup_dim = <x>>
+#wv_constraint2 = #wave.wave_constraint<dim = <M>,
+                                        tile_size = [<BLOCK_M>] -> (BLOCK_M floordiv 4),
                                         wg_constraint = #wg_constraint1>
 func.func private @test_wave2() attributes { wave.hyperparameters = #wv_hyperparams, wave.constraints = [#wg_constraint2, #wv_constraint2] }
 
 // CHECK-LABEL: @test_device
-// CHECK: #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
-#dv_constraint = #wave.device_constraint<dim = <"M">, tile_size = [DEVICE_M] -> (DEVICE_M), device_dim = 0>
+// CHECK: #wave.device_constraint<dim = <M>, tile_size = [#wave.symbol<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
+#dv_constraint = #wave.device_constraint<dim = <M>, tile_size = [<DEVICE_M>] -> (DEVICE_M), device_dim = 0>
 #dv_hyperparams = #wave.hyperparameters<{M = 1024, DEVICE_M = 512}>
 func.func private @test_device() attributes { wave.hyperparameters = #dv_hyperparams, wave.constraints = [#dv_constraint] }

--- a/test/Dialect/Wave/attr-type-invalid.mlir
+++ b/test/Dialect/Wave/attr-type-invalid.mlir
@@ -6,7 +6,7 @@ func.func private @unspecified_tensor() -> !wave.tensor<any of !wave.tensor<any 
 // -----
 
 // expected-error @below {{shape not expected for non-fully specified tensors}}
-"wave_test.create_tensor"() {fully_specified = false, shape = [@A, @B]} : () -> ()
+"wave_test.create_tensor"() {fully_specified = false, shape = [#wave.symbol<A>, #wave.symbol<B>]} : () -> ()
 
 // -----
 

--- a/test/Dialect/Wave/attr-type.mlir
+++ b/test/Dialect/Wave/attr-type.mlir
@@ -1,10 +1,10 @@
 // RUN: water-opt %s | FileCheck %s
 
-// CHECK: #wave.symbol<"A">
-func.func private @attr() attributes { test.foo = #wave.symbol<"A"> }
+// CHECK: #wave.symbol<A>
+func.func private @attr() attributes { test.foo = #wave.symbol<A> }
 
-// CHECK: !wave.tensor<[@A, @B] of bf16>
-func.func private @foo() -> !wave.tensor<[@A, @B] of bf16>
+// CHECK: !wave.tensor<[<A>, <B>] of bf16>
+func.func private @foo() -> !wave.tensor<[<A>, <B>] of bf16>
 
 // CHECK: !wave.tensor<any of bf16>
 func.func private @unspecified_tensor() -> !wave.tensor<any of bf16>

--- a/test/Dialect/Wave/infer-types-force.mlir
+++ b/test/Dialect/Wave/infer-types-force.mlir
@@ -2,19 +2,19 @@
 
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
   // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
-  func.func @iterate_conflict(%arg0: !wave.tensor<[@A] of f32>) {
+  func.func @iterate_conflict(%arg0: !wave.tensor<[<A>] of f32>) {
     // expected-error @below {{type conflict was detected for result #0}}
-    %0 = wave.iterate @I iter_args(%arg0) {
+    %0 = wave.iterate <I> iter_args(%arg0) {
     // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
-    ^bb0(%arg1: !wave.tensor<[@A] of f32>):
-      wave.yield %arg1 : !wave.tensor<[@A] of f32>
-    } : (!wave.tensor<[@A] of f32>) -> (!wave.tensor<any of f32>)
+    ^bb0(%arg1: !wave.tensor<[<A>] of f32>):
+      wave.yield %arg1 : !wave.tensor<[<A>] of f32>
+    } : (!wave.tensor<[<A>] of f32>) -> (!wave.tensor<any of f32>)
     // expected-error @below {{type conflict was detected for result #0}}
-    wave.iterate @I iter_args(%0) {
+    wave.iterate <I> iter_args(%0) {
     // expected-error @below {{type conflict was detected for argument #0 of block #0 in region #0}}
     ^bb0(%arg1: !wave.tensor<any of f32>):
       wave.yield %arg1 : !wave.tensor<any of f32>
-    } : (!wave.tensor<any of f32>) -> (!wave.tensor<[@B] of f32>)
+    } : (!wave.tensor<any of f32>) -> (!wave.tensor<[<B>] of f32>)
     return
   }
 }

--- a/test/Dialect/Wave/infer-types.mlir
+++ b/test/Dialect/Wave/infer-types.mlir
@@ -4,126 +4,126 @@
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
 
 // CHECK-LABEL: @propagate_forward
-func.func @propagate_forward(%a: !wave.tensor<[@A, @B] of bf16>) {
-  // CHECK: (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
-  wave.add %a, %a : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<any of bf16>
+func.func @propagate_forward(%a: !wave.tensor<[<A>, <B>] of bf16>) {
+  // CHECK: (!wave.tensor<[<A>, <B>] of bf16>, !wave.tensor<[<A>, <B>] of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
+  wave.add %a, %a : (!wave.tensor<[<A>, <B>] of bf16>, !wave.tensor<[<A>, <B>] of bf16>) -> !wave.tensor<any of bf16>
   return
 }
 
 // CHECK-LABEL: @propagate_backward
 func.func @propagate_backward() {
   %b = water_test.wave_tensor : !wave.tensor<any of bf16>
-  // CHECK: (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
-  wave.add %b, %b : (!wave.tensor<any of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  // CHECK: (!wave.tensor<[<A>, <B>] of bf16>, !wave.tensor<[<A>, <B>] of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
+  wave.add %b, %b : (!wave.tensor<any of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
   return
 }
 
 // CHECK-LABEL: @propagate_control_flow
-func.func @propagate_control_flow(%a: !wave.tensor<[@A] of f32>, %b: !wave.tensor<[@A] of f32>, %c: i1) {
-  cf.cond_br %c, ^bb0(%a: !wave.tensor<[@A] of f32>), ^bb1(%b: !wave.tensor<[@A] of f32>)
+func.func @propagate_control_flow(%a: !wave.tensor<[<A>] of f32>, %b: !wave.tensor<[<A>] of f32>, %c: i1) {
+  cf.cond_br %c, ^bb0(%a: !wave.tensor<[<A>] of f32>), ^bb1(%b: !wave.tensor<[<A>] of f32>)
 
-^bb0(%arg0: !wave.tensor<[@A] of f32>):
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  wave.exp2 %arg0: (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+^bb0(%arg0: !wave.tensor<[<A>] of f32>):
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  wave.exp2 %arg0: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
   return
 
-^bb1(%arg1: !wave.tensor<[@A] of f32>):
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  wave.exp2 %arg1: (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+^bb1(%arg1: !wave.tensor<[<A>] of f32>):
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  wave.exp2 %arg1: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
   return
 }
 
 // CHECK-LABEL: @propagate_control_flow_block
-func.func @propagate_control_flow_block(%a: !wave.tensor<[@A] of f32>) {
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  %b = wave.exp2 %a: (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+func.func @propagate_control_flow_block(%a: !wave.tensor<[<A>] of f32>) {
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  %b = wave.exp2 %a: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>)
   cf.br ^bb0(%b: !wave.tensor<any of f32>)
 
-// CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>):
+// CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>):
 ^bb0(%arg0: !wave.tensor<any of f32>):
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
   wave.exp2 %arg0: (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
   return
 }
 
 // CHECK-LABEL: @propagate_control_flow_backward
 func.func @propagate_control_flow_backward() {
-  // CHECK: !wave.tensor<[@C] of f32>
+  // CHECK: !wave.tensor<[<C>] of f32>
   %b = water_test.wave_tensor : !wave.tensor<any of f32>
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@C] of f32>)
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<C>] of f32>)
   cf.br ^bb0(%b: !wave.tensor<any of f32>)
 
-// CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@C] of f32>):
+// CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<C>] of f32>):
 ^bb0(%arg0: !wave.tensor<any of f32>):
-  // CHECK: (!wave.tensor<[@C] of f32>) -> !wave.tensor<[@C] of f32>
-  wave.exp2 %arg0: (!wave.tensor<any of f32>) -> !wave.tensor<[@C] of f32>
+  // CHECK: (!wave.tensor<[<C>] of f32>) -> !wave.tensor<[<C>] of f32>
+  wave.exp2 %arg0: (!wave.tensor<any of f32>) -> !wave.tensor<[<C>] of f32>
   return
 }
 
 // CHECK-LABEL: @propagate_structured_control_flow
-func.func @propagate_structured_control_flow(%a: !wave.tensor<[@A] of f32>) {
-  %0 = wave.iterate @I iter_args(%a) {
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+func.func @propagate_structured_control_flow(%a: !wave.tensor<[<A>] of f32>) {
+  %0 = wave.iterate <I> iter_args(%a) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>)
   ^bb0(%arg0: !wave.tensor<any of f32>):
-    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    // CHECK: (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
     %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
-    // CHECK: !wave.tensor<[@A] of f32>
+    // CHECK: !wave.tensor<[<A>] of f32>
     wave.yield %m : !wave.tensor<any of f32>
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  } : (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
   wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
   return
 }
 
 // CHECK-LABEL: @propagate_structured_control_partial
-func.func @propagate_structured_control_partial(%a: !wave.tensor<[@A] of f32>) {
-  %0 = wave.iterate @I iter_args(%a) {
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+func.func @propagate_structured_control_partial(%a: !wave.tensor<[<A>] of f32>) {
+  %0 = wave.iterate <I> iter_args(%a) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>)
   ^bb0(%arg0: !wave.tensor<any of f32>):
-    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-    %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[@A] of f32>
-    // CHECK: !wave.tensor<[@A] of f32>
-    wave.yield %m : !wave.tensor<[@A] of f32>
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  wave.exp2 %0 : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
+    // CHECK: (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+    %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[<A>] of f32>
+    // CHECK: !wave.tensor<[<A>] of f32>
+    wave.yield %m : !wave.tensor<[<A>] of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  } : (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  wave.exp2 %0 : (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
   return
 }
 
 // CHECK-LABEL: @propagate_structured_control_pre
-func.func @propagate_structured_control_pre(%a: !wave.tensor<[@A] of f32>) {
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  %b = wave.exp2 %a : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
-  %0 = wave.iterate @I iter_args(%b) {
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+func.func @propagate_structured_control_pre(%a: !wave.tensor<[<A>] of f32>) {
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  %b = wave.exp2 %a : (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
+  %0 = wave.iterate <I> iter_args(%b) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>)
   ^bb0(%arg0: !wave.tensor<any of f32>):
-    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    // CHECK: (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
     %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
-    // CHECK: !wave.tensor<[@A] of f32>
+    // CHECK: !wave.tensor<[<A>] of f32>
     wave.yield %m : !wave.tensor<any of f32>
   } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
   wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
   return
 }
 
 // CHECK-LABEL: @propagate_structured_control_backward
 func.func @propagate_structured_control_backward() {
-  // CHECK: !wave.tensor<[@A] of f32>
+  // CHECK: !wave.tensor<[<A>] of f32>
   %b = water_test.wave_tensor : !wave.tensor<any of f32>
-  %0 = wave.iterate @I iter_args(%b) {
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>)
+  %0 = wave.iterate <I> iter_args(%b) {
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>)
   ^bb0(%arg0: !wave.tensor<any of f32>):
-    // CHECK: (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
+    // CHECK: (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
     %m = wave.mul %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
-    // CHECK: !wave.tensor<[@A] of f32>
+    // CHECK: !wave.tensor<[<A>] of f32>
     wave.yield %m : !wave.tensor<any of f32>
   } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
-  // CHECK: (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of f32>
-  wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<[@A] of f32>
+  // CHECK: (!wave.tensor<[<A>] of f32>) -> !wave.tensor<[<A>] of f32>
+  wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<[<A>] of f32>
   return
 }
 
@@ -132,10 +132,10 @@ func.func @propagate_structured_control_backward() {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
-  func.func @conflict(%arg0: !wave.tensor<[@A] of f32>) {
-    // expected-error @below {{failed to propagate type information backward: irreconcilable types during type inference from results(!wave.tensor<[@B] of f32>) to operands(!wave.tensor<[@A] of f32>) for results #0}}
-    %0 = wave.exp2 %arg0 : (!wave.tensor<[@A] of f32>) -> !wave.tensor<any of f32>
-    wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<[@B] of f32>
+  func.func @conflict(%arg0: !wave.tensor<[<A>] of f32>) {
+    // expected-error @below {{failed to propagate type information backward: irreconcilable types during type inference from results(!wave.tensor<[<B>] of f32>) to operands(!wave.tensor<[<A>] of f32>) for results #0}}
+    %0 = wave.exp2 %arg0 : (!wave.tensor<[<A>] of f32>) -> !wave.tensor<any of f32>
+    wave.exp2 %0 : (!wave.tensor<any of f32>) -> !wave.tensor<[<B>] of f32>
     return
   }
 }
@@ -143,16 +143,16 @@ module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
-  func.func @iterate_conflict(%arg0: !wave.tensor<[@A] of f32>) {
+  func.func @iterate_conflict(%arg0: !wave.tensor<[<A>] of f32>) {
     // expected-error @below {{type conflict was detected for result #0}}
-    %0 = wave.iterate @I iter_args(%arg0) {
-    ^bb0(%arg1: !wave.tensor<[@A] of f32>):
-      wave.yield %arg1 : !wave.tensor<[@A] of f32>
-    } : (!wave.tensor<[@A] of f32>) -> (!wave.tensor<any of f32>)
-    wave.iterate @I iter_args(%0) {
+    %0 = wave.iterate <I> iter_args(%arg0) {
+    ^bb0(%arg1: !wave.tensor<[<A>] of f32>):
+      wave.yield %arg1 : !wave.tensor<[<A>] of f32>
+    } : (!wave.tensor<[<A>] of f32>) -> (!wave.tensor<any of f32>)
+    wave.iterate <I> iter_args(%0) {
     ^bb0(%arg1: !wave.tensor<any of f32>):
       wave.yield %arg1 : !wave.tensor<any of f32>
-    } : (!wave.tensor<any of f32>) -> (!wave.tensor<[@B] of f32>)
+    } : (!wave.tensor<any of f32>) -> (!wave.tensor<[<B>] of f32>)
     return
   }
 }
@@ -160,11 +160,11 @@ module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
-  func.func @force_fail_forward(%arg0: !wave.tensor<[@A] of f32>) {
+  func.func @force_fail_forward(%arg0: !wave.tensor<[<A>] of f32>) {
     // expected-error @below {{failed to propagate type information forward: intentionally failed to propagate forward}}
     water_test.wave_fail_propagation %arg0, %arg0 {forward}
-      : (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
-      -> (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+      : (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>)
+      -> (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>)
     return
   }
 }
@@ -172,11 +172,11 @@ module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
-  func.func @force_fail_backward(%arg0: !wave.tensor<[@A] of f32>) {
+  func.func @force_fail_backward(%arg0: !wave.tensor<[<A>] of f32>) {
     // expected-error @below {{failed to propagate type information backward: intentionally failed to propagate backward}}
     water_test.wave_fail_propagation %arg0, %arg0 {backward}
-      : (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
-      -> (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+      : (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>)
+      -> (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>)
     return
   }
 }
@@ -184,13 +184,13 @@ module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
-  func.func @type_mismatch_operands(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<[@B] of f32>) {
+  func.func @type_mismatch_operands(%arg0: !wave.tensor<[<A>] of f32>, %arg1: !wave.tensor<[<B>] of f32>) {
     // This op intentionally doesn't have a verifier for shape matching so we can
     // see the failure coming from the analysis/interface trait.
-    // expected-error @below {{ailed to propagate type information backward: irreconcilable types during type inference from results(!wave.tensor<[@A] of f32>) to operands(!wave.tensor<[@B] of f32>) for results #1}}
+    // expected-error @below {{ailed to propagate type information backward: irreconcilable types during type inference from results(!wave.tensor<[<A>] of f32>) to operands(!wave.tensor<[<B>] of f32>) for results #1}}
     water_test.wave_fail_propagation %arg0, %arg1
-      : (!wave.tensor<[@A] of f32>, !wave.tensor<[@B] of f32>)
-      -> (!wave.tensor<[@A] of f32>, !wave.tensor<[@A] of f32>)
+      : (!wave.tensor<[<A>] of f32>, !wave.tensor<[<B>] of f32>)
+      -> (!wave.tensor<[<A>] of f32>, !wave.tensor<[<A>] of f32>)
     return
   }
 }

--- a/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -37,12 +37,12 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
   func.func @lower_register_with_unrealized_cast() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 10, Z = 1, BLOCK_M = 1, BLOCK_K = 2}>} {
     // CHECK-NOT: wave.register
     // CHECK:     %[[ALLOC:.*]] = memref.alloc() : memref<1x6xf32, #gpu.address_space<workgroup>>
-    // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]] : memref<1x6xf32, #gpu.address_space<workgroup>> to !wave.tensor<[@Y, @Z] of f32, <shared>>
+    // CHECK:     %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]] : memref<1x6xf32, #gpu.address_space<workgroup>> to !wave.tensor<[<Y>, <Z>] of f32, <shared>>
     // CHECK:     "test.foo"(%[[CAST]])
     %0 = wave.allocate
-    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
-    : !wave.tensor<[@Y, @Z] of f32, <shared>>
-    "test.foo"(%0) : (!wave.tensor<[@Y, @Z] of f32, <shared>>) -> ()
+    { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> (BLOCK_M, BLOCK_K + 4)>}
+    : !wave.tensor<[<Y>, <Z>] of f32, <shared>>
+    "test.foo"(%0) : (!wave.tensor<[<Y>, <Z>] of f32, <shared>>) -> ()
     return
   }
 }
@@ -159,14 +159,14 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 func.func @lower_alloc_view() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
   // CHECK: %[[BUFF:.*]] = memref.alloc() : memref<256xi8, #gpu.address_space<workgroup>>
   %parent = wave.allocate { distributed_shape = #wave.expr<[] -> (256)> }
-    : !wave.tensor<[@M,@N,@K] of i8, <shared>>
+    : !wave.tensor<[<M>,<N>,<K>] of i8, <shared>>
 
   // CHECK: %[[OFF:.*]] = arith.constant 128 : index
   // CHECK: %[[VIEW:.*]] = memref.view %[[BUFF]][%[[OFF]]][]
   // CHECK-SAME: : memref<256xi8, #gpu.address_space<workgroup>> to memref<4x32xbf16, #gpu.address_space<workgroup>>
-  %buf = wave.allocate in %parent : !wave.tensor<[@M,@N,@K] of i8, <shared>>
-    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+  %buf = wave.allocate in %parent : !wave.tensor<[<M>,<N>,<K>] of i8, <shared>>
+    { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
   return
   }
 }
@@ -178,8 +178,8 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, K= 128}>}  {
   // CHECK: memref.alloc() : memref<4x32xbf16, #gpu.address_space<workgroup>>
   %buf = wave.allocate
-    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+    { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> (BLOCK_M, BLOCK_K + 4)>}
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
   return
   }
 }
@@ -188,18 +188,18 @@ func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameter
 
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
 // CHECK-LABEL: @lower_read
-func.func @lower_read(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
+func.func @lower_read(%mem: !wave.tensor<[<M>, <N>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %0 = wave.read %mem index {
       // CHECK: %[[BIDX_X:.*]] = gpu.block_id x
       // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
       // Note: BLOCK_M = 64
       // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 mod 64)>()[%[[BIDX_X]], %[[TIDX_X]]]
-      M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 mod 64, 1, 64),
+      <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
       // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
       // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 8) * _T1, BLOCK_N ceildiv 8, 1)}
-     : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
+      <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}
+     : (!wave.tensor<[<M>, <N>] of f16, <global>>) -> vector<8xf16>
      // CHECK: %[[VEC:.+]] = vector.load {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
 
   return
@@ -210,18 +210,18 @@ func.func @lower_read(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes 
 
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
 // CHECK-LABEL: @lower_read_non_innermost_dim
-func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
+func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[<M>, <N>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %0 = wave.read %mem index {
     // CHECK: %[[BIDX_X:.*]] = gpu.block_id x
     // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
     // Note: BLOCK_M = 64
     // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 * 8)>()[%[[BIDX_X]], %[[TIDX_X]]]
-    M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 * 8 , 8, 64),
+    <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 * 8 , 8, 64),
     // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
     // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
     // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-    N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 8) * _T1, 1, 1)}
-    : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
+    <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}
+    : (!wave.tensor<[<M>, <N>] of f16, <global>>) -> vector<8xf16>
     // CHECK: %[[PAD:.*]] = arith.constant {{.*}} : f16
     // CHECK: vector.transfer_read {{.*}}[%[[ROW]], %[[COL]]], %[[PAD]] {permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
   return
@@ -232,22 +232,22 @@ func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <glo
 
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: @lower_read_masked
-  func.func @lower_read_masked(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
+  func.func @lower_read_masked(%mem: !wave.tensor<[<M>, <N>] of f16, <global>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 100, N = 50}>} {
 
     %v = wave.read %mem index {
         // CHECK: %[[BIDX_X:.*]] = gpu.block_id x
         // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
         // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1)>()[%[[BIDX_X]], %[[TIDX_X]]]
-        M : [BLOCK_M, _WG0, _T0] -> (_WG0 * BLOCK_M + _T0, 1, 64),
+        <M> : [<BLOCK_M>, <WG0>, <T0>] -> (WG0 * BLOCK_M + T0, 1, 64),
         // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
         // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
         // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 32)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
-        N : [_WG1, _T1, BLOCK_N] -> (_WG1 * BLOCK_N + _T1 * 32, 4, 1)
+        <N> : [<WG1>, <T1>, <BLOCK_N>] -> (WG1 * BLOCK_N + T1 * 32, 4, 1)
       } { bounds = #wave.read_write_bounds<{
-        M = #wave.expr<[M] -> (M)>,
-        N = #wave.expr<[N] -> (N)>}>}
-      : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<4xf16>
+        M = #wave.expr<[<M>] -> (M)>,
+        N = #wave.expr<[<N>] -> (N)>}>}
+      : (!wave.tensor<[<M>, <N>] of f16, <global>>) -> vector<4xf16>
       // Bounds for dim 0.
       // CHECK: %[[DIM0_SIZE:.+]] = affine.apply affine_map<() -> (100)>()
       // CHECK: %[[DIM0_CMP:.+]] = arith.cmpi slt, %[[ROW]], %[[DIM0_SIZE]]
@@ -274,15 +274,15 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: @lower_read_masked_non_innermost_dim
-  func.func @lower_read_masked_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
+  func.func @lower_read_masked_non_innermost_dim(%mem: !wave.tensor<[<M>, <N>] of f16, <global>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 100, N = 50}>} {
     %v = wave.read %mem index {
-        M : [BLOCK_M, _WG0, _T0] -> (_WG0 * BLOCK_M + _T0, 8, 64),
-        N : [_WG1, _T1, BLOCK_N] -> (_WG1 * BLOCK_N + _T1 * 32, 1, 1)
+        <M> : [<BLOCK_M>, <WG0>, <T0>] -> (WG0 * BLOCK_M + T0, 8, 64),
+        <N> : [<WG1>, <T1>, <BLOCK_N>] -> (WG1 * BLOCK_N + T1 * 32, 1, 1)
       } { bounds = #wave.read_write_bounds<{
-        M = #wave.expr<[M] -> (M)>,
-        N = #wave.expr<[N] -> (N)>}>}
-      : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
+        M = #wave.expr<[<M>] -> (M)>,
+        N = #wave.expr<[<N>] -> (N)>}>}
+      : (!wave.tensor<[<M>, <N>] of f16, <global>>) -> vector<8xf16>
       // CHECK: %[[MASK:.+]] = arith.andi {{.*}}, {{.*}}
       // CHECK: %[[PAD:.*]] = arith.constant {{.*}} : f16
       // CHECK: vector.transfer_read {{.*}}[{{.*}}, {{.*}}], %[[PAD]], %[[MASK]] {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
@@ -294,7 +294,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
 // CHECK-LABEL: @lower_write
-func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
+func.func @lower_write(%mem: !wave.tensor<[<M>, <N>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %cst = arith.constant 0.0 : f16
   %reg = wave.register %cst : vector<8xf16>
   wave.write %reg, %mem index {
@@ -302,12 +302,12 @@ func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes
       // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
       // Note: BLOCK_M = 64
       // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 mod 64)>()[%[[BIDX_X]], %[[TIDX_X]]]
-      M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 mod 64, 1, 64),
+     <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
       // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
       // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 8) * _T1, BLOCK_N ceildiv 8, 1)}
-     : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
+     <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}
+     : vector<8xf16>, !wave.tensor<[<M>, <N>] of f16, <global>>
      // CHECK: vector.store {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
 
   return
@@ -318,7 +318,7 @@ func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes
 
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
 // CHECK-LABEL: @lower_write_non_innermost
-func.func @lower_write_non_innermost(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
+func.func @lower_write_non_innermost(%mem: !wave.tensor<[<M>, <N>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %cst = arith.constant 0.0 : f16
   %reg = wave.register %cst : vector<8xf16>
   wave.write %reg, %mem index {
@@ -326,12 +326,12 @@ func.func @lower_write_non_innermost(%mem: !wave.tensor<[@M, @N] of f16, <global
       // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
       // Note: BLOCK_M = 64
       // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 mod 64)>()[%[[BIDX_X]], %[[TIDX_X]]]
-      M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 mod 64, 8, 64),
+      <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 8, 64),
       // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
       // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 8) * _T1, 1, 1)}
-     : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
+      <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}
+     : vector<8xf16>, !wave.tensor<[<M>, <N>] of f16, <global>>
      // CHECK: vector.transfer_write {{.*}}, {{.*}}[{{.*}}, {{.*}}] {permutation_map = affine_map<(d0, d1) -> (d0)>} : vector<8xf16>, memref<{{.*}}xf16{{.*}}>
 
   return

--- a/test/Dialect/Wave/normal-forms.mlir
+++ b/test/Dialect/Wave/normal-forms.mlir
@@ -22,7 +22,7 @@ module attributes {wave.normal_form = #wave.normal_form<index_exprs>} {
   func.func @bar() {
     %0 = arith.constant 0.0 : f32
     // expected-error @below {{normal form requires index expressions to be provided for all supported wave dialect operations}}
-    wave.register %0 : !wave.tensor<[@X] of f32, <register>>
+    wave.register %0 : !wave.tensor<[<X>] of f32, <register>>
     return
   }
 }

--- a/test/Dialect/Wave/ops-invalid.mlir
+++ b/test/Dialect/Wave/ops-invalid.mlir
@@ -1,43 +1,43 @@
 // RUN: water-opt %s --split-input-file --verify-diagnostics
 
-func.func @mismatch_element_lhs_acc(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@C, @B] of f32>, %acc: !wave.tensor<[@A, @C] of bf16>) {
+func.func @mismatch_element_lhs_acc(%lhs: !wave.tensor<[<A>, <B>] of f32>, %rhs: !wave.tensor<[<C>, <B>] of f32>, %acc: !wave.tensor<[<A>, <C>] of bf16>) {
   // expected-error @below {{unexpected accumulator/result elemental type 'bf16' for MMA kind f32_16x16x16_f16}}
-  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@C, @B] of f32>, !wave.tensor<[@A, @C] of bf16>) -> !wave.tensor<[@A, @C] of bf16>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[<A>, <B>] of f32>, !wave.tensor<[<C>, <B>] of f32>, !wave.tensor<[<A>, <C>] of bf16>) -> !wave.tensor<[<A>, <C>] of bf16>
 }
 
 // -----
 
-func.func @mismatch_element_int(%lhs: !wave.tensor<[@A, @B] of i32>, %rhs: !wave.tensor<[@C, @B] of i32>, %acc: !wave.tensor<[@A, @C] of i32>) {
+func.func @mismatch_element_int(%lhs: !wave.tensor<[<A>, <B>] of i32>, %rhs: !wave.tensor<[<C>, <B>] of i32>, %acc: !wave.tensor<[<A>, <C>] of i32>) {
   // expected-error @below {{unexpected lhs/rhs elemental type 'i32' for MMA kind i32_32x32x16_i8}}
-  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<i32_32x32x16_i8>} : (!wave.tensor<[@A, @B] of i32>, !wave.tensor<[@C, @B] of i32>, !wave.tensor<[@A, @C] of i32>) -> !wave.tensor<[@A, @C] of i32>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<i32_32x32x16_i8>} : (!wave.tensor<[<A>, <B>] of i32>, !wave.tensor<[<C>, <B>] of i32>, !wave.tensor<[<A>, <C>] of i32>) -> !wave.tensor<[<A>, <C>] of i32>
 }
 
 // -----
 
-func.func @mismatch_element_lhs_rhs(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@C, @B] of bf16>, %acc: !wave.tensor<[@A, @C] of f32>) {
+func.func @mismatch_element_lhs_rhs(%lhs: !wave.tensor<[<A>, <B>] of f32>, %rhs: !wave.tensor<[<C>, <B>] of bf16>, %acc: !wave.tensor<[<A>, <C>] of f32>) {
   // expected-error @below {{expected LHS and RHS elemental types to match, got 'f32', 'bf16'}}
-  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@C, @B] of bf16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[<A>, <B>] of f32>, !wave.tensor<[<C>, <B>] of bf16>, !wave.tensor<[<A>, <C>] of f32>) -> !wave.tensor<[<A>, <C>] of f32>
 }
 
 // -----
 
-func.func @mismatch_dim_lhs_rhs(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@B, @C] of f16>, %acc: !wave.tensor<[@A, @C] of f32>) {
-  // expected-error @below {{expected LHS dimension #1 (#wave.symbol<"B">) to match RHS dimension #1 (#wave.symbol<"C">)}}
-  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@B, @C] of f16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
+func.func @mismatch_dim_lhs_rhs(%lhs: !wave.tensor<[<A>, <B>] of f16>, %rhs: !wave.tensor<[<B>, <C>] of f16>, %acc: !wave.tensor<[<A>, <C>] of f32>) {
+  // expected-error @below {{expected LHS dimension #1 (#wave.symbol<B>) to match RHS dimension #1 (#wave.symbol<C>)}}
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[<A>, <B>] of f16>, !wave.tensor<[<B>, <C>] of f16>, !wave.tensor<[<A>, <C>] of f32>) -> !wave.tensor<[<A>, <C>] of f32>
 }
 
 // -----
 
-func.func @mismatch_dim_lhs_acc(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@C, @B] of f16>, %acc: !wave.tensor<[@E, @D] of f32>) {
-  // expected-error @below {{expected LHS dimension #0 (#wave.symbol<"A">) to match accumulator dimension #0 (#wave.symbol<"E">)}}
-  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@C, @B] of f16>, !wave.tensor<[@E, @D] of f32>) -> !wave.tensor<[@E, @D] of f32>
+func.func @mismatch_dim_lhs_acc(%lhs: !wave.tensor<[<A>, <B>] of f16>, %rhs: !wave.tensor<[<C>, <B>] of f16>, %acc: !wave.tensor<[<E>, <D>] of f32>) {
+  // expected-error @below {{expected LHS dimension #0 (#wave.symbol<A>) to match accumulator dimension #0 (#wave.symbol<E>)}}
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[<A>, <B>] of f16>, !wave.tensor<[<C>, <B>] of f16>, !wave.tensor<[<E>, <D>] of f32>) -> !wave.tensor<[<E>, <D>] of f32>
 }
 
 // -----
 
-func.func @mismatch_dim_rhs_acc(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@C, @B] of f16>, %acc: !wave.tensor<[@A, @D] of f32>) {
-  // expected-error @below {{expected RHS dimension #0 (#wave.symbol<"C">) to match accumulator dimension #1 (#wave.symbol<"D">)}}
-  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@C, @B] of f16>, !wave.tensor<[@A, @D] of f32>) -> !wave.tensor<[@A, @D] of f32>
+func.func @mismatch_dim_rhs_acc(%lhs: !wave.tensor<[<A>, <B>] of f16>, %rhs: !wave.tensor<[<C>, <B>] of f16>, %acc: !wave.tensor<[<A>, <D>] of f32>) {
+  // expected-error @below {{expected RHS dimension #0 (#wave.symbol<C>) to match accumulator dimension #1 (#wave.symbol<D>)}}
+  wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[<A>, <B>] of f16>, !wave.tensor<[<C>, <B>] of f16>, !wave.tensor<[<A>, <D>] of f32>) -> !wave.tensor<[<A>, <D>] of f32>
 }
 
 // -----
@@ -51,7 +51,7 @@ func.func @invalid_register_type(%arg0: f32) {
 
 func.func @register_type_mismatch(%arg0: f32) {
   // expected-error @below {{expected the type of the init value to match the elemental type of the result}}
-  "wave.register"(%arg0) : (f32) -> !wave.tensor<[@A, @B] of bf16>
+  "wave.register"(%arg0) : (f32) -> !wave.tensor<[<A>, <B>] of bf16>
 }
 
 // -----
@@ -65,7 +65,7 @@ func.func @register_underspecified(%arg0: f32) {
 
 func.func @iterate_mismatching_results(%arg0: !wave.tensor<any of f32>, %arg1: !wave.tensor<any of f32>) {
   // expected-error @below {{expects the same number of iter_args (2) and results (1)}}
-  wave.iterate @I iter_args(%arg0, %arg1) {
+  wave.iterate <I> iter_args(%arg0, %arg1) {
   ^bb0(%arg2: !wave.tensor<any of f32>, %arg3: !wave.tensor<any of f32>):
     wave.yield %arg2 : !wave.tensor<any of f32>
   } : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
@@ -73,12 +73,12 @@ func.func @iterate_mismatching_results(%arg0: !wave.tensor<any of f32>, %arg1: !
 
 // -----
 
-func.func @iterate_mismatching_results(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<any of f32>) {
-  // expected-error @below {{along control flow edge from parent operands to Region #0: source type #0 '!wave.tensor<[@A] of f32>' should match input type #0 '!wave.tensor<[@B] of f32>'}}
-  wave.iterate @I iter_args(%arg0, %arg1) {
-  ^bb0(%arg2: !wave.tensor<[@B] of f32>, %arg3: !wave.tensor<any of f32>):
-    wave.yield %arg2, %arg3 : !wave.tensor<[@B] of f32>, !wave.tensor<any of f32>
-  } : (!wave.tensor<[@A] of f32>, !wave.tensor<any of f32>) -> (!wave.tensor<any of f32>, !wave.tensor<any of f32>)
+func.func @iterate_mismatching_results(%arg0: !wave.tensor<[<A>] of f32>, %arg1: !wave.tensor<any of f32>) {
+  // expected-error @below {{along control flow edge from parent operands to Region #0: source type #0 '!wave.tensor<[<A>] of f32>' should match input type #0 '!wave.tensor<[<B>] of f32>'}}
+  wave.iterate <I> iter_args(%arg0, %arg1) {
+  ^bb0(%arg2: !wave.tensor<[<B>] of f32>, %arg3: !wave.tensor<any of f32>):
+    wave.yield %arg2, %arg3 : !wave.tensor<[<B>] of f32>, !wave.tensor<any of f32>
+  } : (!wave.tensor<[<A>] of f32>, !wave.tensor<any of f32>) -> (!wave.tensor<any of f32>, !wave.tensor<any of f32>)
 }
 
 // -----
@@ -87,7 +87,7 @@ func.func @iterate_mismatching_results(%arg0: !wave.tensor<[@A] of f32>, %arg1: 
 func.func @index_attr_missing_step_stride(%arg0: f32) {
   // expected-error @+2 {{expected ','}}
   // expected-error @+1 {{custom op 'wave.register' expected three affine expressions for '(start, step, stride)'}}
-  wave.register %arg0 index {X : [_WG0] -> (_WG0)} : !wave.tensor<[@M] of f32, <register>>
+  wave.register %arg0 index {<X> : [<WG0>] -> (WG0)} : !wave.tensor<[<M>] of f32, <register>>
   return
 }
 
@@ -97,7 +97,7 @@ func.func @index_attr_missing_step_stride(%arg0: f32) {
 func.func @index_attr_missing_stride(%arg0: f32) {
   // expected-error @+2 {{expected ','}}
   // expected-error @+1 {{custom op 'wave.register' expected three affine expressions for '(start, step, stride)'}}
-  wave.register %arg0 index {X : [_WG0] -> (_WG0, 1)} : !wave.tensor<[@M] of f32, <register>>
+  wave.register %arg0 index {<X> : [<WG0>] -> (WG0, 1)} : !wave.tensor<[<M>] of f32, <register>>
   return
 }
 
@@ -105,38 +105,38 @@ func.func @index_attr_missing_stride(%arg0: f32) {
 
 func.func @index_attr_not_dict(%arg0: f32) {
   // expected-error @+1 {{'wave.register' op attribute 'index' failed to satisfy constraint: dictionary of named attribute values}}
-  "wave.register"(%arg0) { index = 42 } : (f32) -> !wave.tensor<[@M] of f32, <register>>
+  "wave.register"(%arg0) { index = 42 } : (f32) -> !wave.tensor<[<M>] of f32, <register>>
   return
 }
 
 // -----
 
-func.func @mismatch_shape_binary(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@B, @C] of f32>) {
-  // expected-error @below {{expected operand #1 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
-  wave.add %lhs, %rhs : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@B, @C] of f32>) -> !wave.tensor<any of f32>
+func.func @mismatch_shape_binary(%lhs: !wave.tensor<[<A>, <B>] of f32>, %rhs: !wave.tensor<[<B>, <C>] of f32>) {
+  // expected-error @below {{expected operand #1 dimension #0 (#wave.symbol<B>) to match operand #0 dimension #0 (#wave.symbol<A>)}}
+  wave.add %lhs, %rhs : (!wave.tensor<[<A>, <B>] of f32>, !wave.tensor<[<B>, <C>] of f32>) -> !wave.tensor<any of f32>
 }
 
 // -----
 
-func.func @mismatch_shape_unary(%lhs: !wave.tensor<[@A, @B] of f32>) {
-  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
-  wave.exp2 %lhs : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@B, @C] of f32>
+func.func @mismatch_shape_unary(%lhs: !wave.tensor<[<A>, <B>] of f32>) {
+  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<B>) to match operand #0 dimension #0 (#wave.symbol<A>)}}
+  wave.exp2 %lhs : (!wave.tensor<[<A>, <B>] of f32>) -> !wave.tensor<[<B>, <C>] of f32>
   return
 }
 
 // -----
 
-func.func @mismatch_shape_read(%lhs: !wave.tensor<[@A, @B] of f32, <global>>) {
-  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
-  wave.read %lhs : (!wave.tensor<[@A, @B] of f32, <global>>) -> !wave.tensor<[@B, @C] of f32, <register>>
+func.func @mismatch_shape_read(%lhs: !wave.tensor<[<A>, <B>] of f32, <global>>) {
+  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<B>) to match operand #0 dimension #0 (#wave.symbol<A>)}}
+  wave.read %lhs : (!wave.tensor<[<A>, <B>] of f32, <global>>) -> !wave.tensor<[<B>, <C>] of f32, <register>>
   return
 }
 
 // -----
 
-func.func @mismatch_shape_write(%lhs: !wave.tensor<[@A, @B] of f32, <register>>, %rhs: !wave.tensor<[@B, @C] of f32, <global>>) {
-  // expected-error @below {{expected operand #1 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
-  wave.write %lhs, %rhs : !wave.tensor<[@A, @B] of f32, <register>>, !wave.tensor<[@B, @C] of f32, <global>>
+func.func @mismatch_shape_write(%lhs: !wave.tensor<[<A>, <B>] of f32, <register>>, %rhs: !wave.tensor<[<B>, <C>] of f32, <global>>) {
+  // expected-error @below {{expected operand #1 dimension #0 (#wave.symbol<B>) to match operand #0 dimension #0 (#wave.symbol<A>)}}
+  wave.write %lhs, %rhs : !wave.tensor<[<A>, <B>] of f32, <register>>, !wave.tensor<[<B>, <C>] of f32, <global>>
 }
 
 // -----
@@ -144,8 +144,8 @@ func.func @mismatch_shape_write(%lhs: !wave.tensor<[@A, @B] of f32, <register>>,
 
 func.func @empty_distributed_shape() {
   // expected-error @below {{wave expression attribute must have at least one dimension}}
-  %buf = wave.allocate { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> ()>}
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+  %buf = wave.allocate { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> ()>}
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
 }
 
 // -----
@@ -153,17 +153,17 @@ func.func @empty_distributed_shape() {
 func.func @alloc_offset_no_parent() {
   // expected-error @below {{expects parent and offset to be present simultaneously}}
   %buf = wave.allocate { distributed_shape = #wave.expr<[] -> (42)>, offset = 42}
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
 }
 
 // -----
 
 func.func @alloc_parent_no_offset() {
   %alloc = wave.allocate { distributed_shape = #wave.expr<[] -> (100)> }
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
   // expected-error @below {{expects parent and offset to be present simultaneously}}
-  %buf = wave.allocate in %alloc : !wave.tensor<[@M, @K] of bf16, <shared>> { distributed_shape = #wave.expr<[] -> (42)>}
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+  %buf = wave.allocate in %alloc : !wave.tensor<[<M>, <K>] of bf16, <shared>> { distributed_shape = #wave.expr<[] -> (42)>}
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
 }
 
 // -----
@@ -177,10 +177,10 @@ module attributes { wave.hyperparameters = #wave.hyperparameters<{}> } {
 // -----
 
 module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43}> } {
-  // expected-error @below {{region #0 block #0 argument type #0 uses symbolic value #wave.symbol<"B"> not provided as a hyperparameter}}
+  // expected-error @below {{region #0 block #0 argument type #0 uses symbolic value #wave.symbol<B> not provided as a hyperparameter}}
   // expected-note @below {{available symbols: A, C}}
   // expected-note @below {{NYI support for symbol lowering}}
-  func.func @missing_hyperparam_func(%arg0: !wave.tensor<[@B] of f32>) {
+  func.func @missing_hyperparam_func(%arg0: !wave.tensor<[<B>] of f32>) {
     return
   }
 }
@@ -190,10 +190,10 @@ module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43
 
 module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43}> } {
   func.func @missing_hyperparam_result(%arg0: !wave.tensor<any of f32>) {
-    // expected-error @below {{result type #0 uses symbolic value #wave.symbol<"B"> not provided as a hyperparameter}}
+    // expected-error @below {{result type #0 uses symbolic value #wave.symbol<B> not provided as a hyperparameter}}
     // expected-note @below {{available symbols: A, C}}
     // expected-note @below {{NYI support for symbol lowering}}
-    wave.add %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[@B] of f32>
+    wave.add %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[<B>] of f32>
     return
   }
 }
@@ -203,7 +203,7 @@ module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43
 // expected-warning @below {{unused hyperparameter: C}}
 module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43}> } {
   func.func @missing_hyperparam_result(%arg0: !wave.tensor<any of f32>) {
-    wave.add %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[@A] of f32>
+    wave.add %arg0, %arg0 : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[<A>] of f32>
     return
   }
 }
@@ -211,14 +211,14 @@ module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
-  func.func @index_key_unspecified(%mem: !wave.tensor<[@M] of f16, <global>>)
+  func.func @index_key_unspecified(%mem: !wave.tensor<[<M>] of f16, <global>>)
   attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128}>}  {
     // expected-error @below {{attribute "index" uses symbolic value "N" not provided as a hyperparameter}}
     // expected-note @below {{BLOCK_M, BLOCK_N, M}}
     %0 = wave.read %mem index {
-        M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 mod 64, 1, 64),
-        N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 2) * _T1, BLOCK_N ceildiv 2, 1)}
-      : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+        <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
+        <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}
+      : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
     return
   }
 }
@@ -226,14 +226,14 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
-  func.func @index_value_unspecified(%mem: !wave.tensor<[@M] of f16, <global>>)
+  func.func @index_value_unspecified(%mem: !wave.tensor<[<M>] of f16, <global>>)
   attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 256}>}  {
-    // expected-error @below {{attribute "index" uses symbolic value #wave.symbol<"BLOCK_M"> not provided as a hyperparameter}}
+    // expected-error @below {{attribute "index" uses symbolic value #wave.symbol<BLOCK_M> not provided as a hyperparameter}}
     // expected-note @below {{available symbols: M, N}}
     %0 = wave.read %mem index {
-        M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 mod 64, 1, 64),
-        N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 2) * _T1, BLOCK_N ceildiv 2, 1)}
-      : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+        <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
+        <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}
+      : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
     return
   }
 }
@@ -241,85 +241,85 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
-  func.func @elements_per_thread_mismatch(%mem: !wave.tensor<[@M] of f16, <global>>)
+  func.func @elements_per_thread_mismatch(%mem: !wave.tensor<[<M>] of f16, <global>>)
   attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
     // expected-error @below {{expected result vector type to have the number of elements per thread matching the attribute (4), got 42}}
-    %0 = wave.read %mem {elements_per_thread=4}: (!wave.tensor<[@M] of f16, <global>>) -> vector<42xf16>
+    %0 = wave.read %mem {elements_per_thread=4}: (!wave.tensor<[<M>] of f16, <global>>) -> vector<42xf16>
     return
   }
 }
 
 // -----
 
-func.func @bounds_missing_dim(%mem: !wave.tensor<[@M, @N] of f32>, %val: !wave.tensor<[@M, @N] of f32, <register>>) {
+func.func @bounds_missing_dim(%mem: !wave.tensor<[<M>, <N>] of f32>, %val: !wave.tensor<[<M>, <N>] of f32, <register>>) {
   // expected-error @below {{bounds not provided for memory tensor symbol 'N'}}
-  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.expr<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
+  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.expr<[<BLOCK_M>] -> (BLOCK_M * 64)>}> } : !wave.tensor<[<M>, <N>] of f32, <register>>, !wave.tensor<[<M>, <N>] of f32>
   return
 }
 
 // -----
 
-func.func @bounds_extraneous_dim(%mem: !wave.tensor<[@N] of f32>, %val: !wave.tensor<[@N] of f32, <register>>) {
+func.func @bounds_extraneous_dim(%mem: !wave.tensor<[<N>] of f32>, %val: !wave.tensor<[<N>] of f32, <register>>) {
   // expected-error @below {{'bounds' specified for a symbol "M" not used in the indexed memory tensor}}
-  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.expr<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@N] of f32, <register>>, !wave.tensor<[@N] of f32>
+  wave.write %val, %mem { bounds = #wave.read_write_bounds<{ M = #wave.expr<[<BLOCK_M>] -> (BLOCK_M * 64)>}> } : !wave.tensor<[<N>] of f32, <register>>, !wave.tensor<[<N>] of f32>
   return
 }
 
 // -----
 
-func.func @bounds_wrong_type(%mem: !wave.tensor<[@N] of f32>) {
+func.func @bounds_wrong_type(%mem: !wave.tensor<[<N>] of f32>) {
   // expected-error @below {{'bounds' values must be WaveExprAttr, got 42 : i64}}
-  wave.read %mem { bounds = #wave.read_write_bounds<{ N = 42 }> } : (!wave.tensor<[@N] of f32>) -> !wave.tensor<[@N] of f32, <register>>
+  wave.read %mem { bounds = #wave.read_write_bounds<{ N = 42 }> } : (!wave.tensor<[<N>] of f32>) -> !wave.tensor<[<N>] of f32, <register>>
   return
 }
 
 // -----
 
-func.func @read_index_multi_step(%mem: !wave.tensor<[@M, @N] of f32>) {
+func.func @read_index_multi_step(%mem: !wave.tensor<[<M>, <N>] of f32>) {
   // expected-error @below {{'index' has more than one entry with non-unit step}}
   // expected-note @below {{second non-unit step dimension: 1}}
   wave.read %mem index {
-    M : [_T0] -> (_T0, 2, 1),
-    N : [_T1] -> (_T1, 2, 1)
-  } : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<any of f32, <register>>
+    <M> : [<T0>] -> (T0, 2, 1),
+    <N> : [<T1>] -> (T1, 2, 1)
+  } : (!wave.tensor<[<M>, <N>] of f32>) -> !wave.tensor<any of f32, <register>>
   return
 }
 
 // -----
 
-func.func @read_index_elements_per_thread_mismatch(%mem: !wave.tensor<[@M, @N] of f32>) {
+func.func @read_index_elements_per_thread_mismatch(%mem: !wave.tensor<[<M>, <N>] of f32>) {
   // expected-error @below {{vectorized dimension step in the index expression with current hyperparameters (2) doesn't match the explicitly specified elements per thread value (4)}}
   wave.read %mem index {
-    M : [_T0] -> (_T0, 2, 1),
-    N : [_T1] -> (_T1, 1, 1)
+    <M> : [<T0>] -> (T0, 2, 1),
+    <N> : [<T1>] -> (T1, 1, 1)
   } {
     elements_per_thread = 4
-  } : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<any of f32, <register>>
+  } : (!wave.tensor<[<M>, <N>] of f32>) -> !wave.tensor<any of f32, <register>>
   return
 }
 
 
 // -----
 
-func.func @read_index_type_mismatch(%mem: !wave.tensor<[@M, @N] of f32>) {
+func.func @read_index_type_mismatch(%mem: !wave.tensor<[<M>, <N>] of f32>) {
   // expected-error @below {{vectorized dimension step in the index expression with current hyperparameters (2) doesn't match the vector size (4)}}
   wave.read %mem index {
-    M : [_T0] -> (_T0, 2, 1),
-    N : [_T1] -> (_T1, 1, 1)
-  } : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
+    <M> : [<T0>] -> (T0, 2, 1),
+    <N> : [<T1>] -> (T1, 1, 1)
+  } : (!wave.tensor<[<M>, <N>] of f32>) -> vector<4xf32>
   return
 }
 
 // -----
 
-func.func @read_index_multi_step_eval(%mem: !wave.tensor<[@M, @N] of f32>) attributes {
+func.func @read_index_multi_step_eval(%mem: !wave.tensor<[<M>, <N>] of f32>) attributes {
   wave.hyperparameters = #wave.hyperparameters<{X = 1, Y = 1, M = 100, N = 200}>
 } {
   // expected-error @below {{'index' has more than one entry with non-unit step}}
   // expected-note @below {{second non-unit step dimension: 1}}
   wave.read %mem index {
-    M : [_T0, X] -> (_T0, 2 * X, 1),
-    N : [_T1, X, Y] -> (_T1, X + Y, 1)
-  } : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
+    <M> : [<T0>, <X>] -> (T0, 2 * X, 1),
+    <N> : [<T1>, <X>, <Y>] -> (T1, X + Y, 1)
+  } : (!wave.tensor<[<M>, <N>] of f32>) -> vector<4xf32>
   return
 }

--- a/test/Dialect/Wave/ops.mlir
+++ b/test/Dialect/Wave/ops.mlir
@@ -8,36 +8,36 @@
 //===---------------------------------------------------------------------------
 
 // CHECK-LABEL: @mma
-func.func @mma(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave.tensor<[@C, @B] of f16>, %acc: !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32> {
+func.func @mma(%lhs: !wave.tensor<[<A>, <B>] of f16>, %rhs: !wave.tensor<[<C>, <B>] of f16>, %acc: !wave.tensor<[<A>, <C>] of f32>) -> !wave.tensor<[<A>, <C>] of f32> {
   // CHECK: wave.mma
-  %0 = wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[@A, @B] of f16>, !wave.tensor<[@C, @B] of f16>, !wave.tensor<[@A, @C] of f32>) -> !wave.tensor<[@A, @C] of f32>
-  return %0 : !wave.tensor<[@A, @C] of f32>
+  %0 = wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>} : (!wave.tensor<[<A>, <B>] of f16>, !wave.tensor<[<C>, <B>] of f16>, !wave.tensor<[<A>, <C>] of f32>) -> !wave.tensor<[<A>, <C>] of f32>
+  return %0 : !wave.tensor<[<A>, <C>] of f32>
 }
 
 // CHECK-LABEL: @unary
-func.func @unary(%value: !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16> {
+func.func @unary(%value: !wave.tensor<[<A>, <B>] of bf16>) -> !wave.tensor<[<A>, <B>] of bf16> {
   // CHECK: wave.exp2
-  %0 = wave.exp2 %value : (!wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
-  return %0 : !wave.tensor<[@A, @B] of bf16>
+  %0 = wave.exp2 %value : (!wave.tensor<[<A>, <B>] of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
+  return %0 : !wave.tensor<[<A>, <B>] of bf16>
 }
 
 // CHECK-LABEL: @binary
-func.func @binary(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16> {
+func.func @binary(%lhs: !wave.tensor<[<A>, <B>] of bf16>, %rhs: !wave.tensor<any of bf16>) -> !wave.tensor<[<A>, <B>] of bf16> {
   // CHECK: wave.add
-  %0 = wave.add %lhs, %rhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  %0 = wave.add %lhs, %rhs : (!wave.tensor<[<A>, <B>] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
   // CHECK: wave.mul
-  %1 = wave.mul %0, %rhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  %1 = wave.mul %0, %rhs : (!wave.tensor<[<A>, <B>] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
   // CHECK: wave.div
-  %2 = wave.div %1, %lhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
-  return %2 : !wave.tensor<[@A, @B] of bf16>
+  %2 = wave.div %1, %lhs : (!wave.tensor<[<A>, <B>] of bf16>, !wave.tensor<[<A>, <B>] of bf16>) -> !wave.tensor<[<A>, <B>] of bf16>
+  return %2 : !wave.tensor<[<A>, <B>] of bf16>
 }
 
 // CHECK-LABEL: @memory
-func.func @memory(%mem: !wave.tensor<[@X] of f32, <global>>) {
+func.func @memory(%mem: !wave.tensor<[<X>] of f32, <global>>) {
   // CHECK: wave.read
-  %0 = wave.read %mem : (!wave.tensor<[@X] of f32, <global>>) -> !wave.tensor<any of f32, <register>>
+  %0 = wave.read %mem : (!wave.tensor<[<X>] of f32, <global>>) -> !wave.tensor<any of f32, <register>>
   // CHECK: wave.write
-  wave.write %0, %mem : !wave.tensor<any of f32, <register>>, !wave.tensor<[@X] of f32, <global>>
+  wave.write %0, %mem : !wave.tensor<any of f32, <register>>, !wave.tensor<[<X>] of f32, <global>>
   return
 }
 
@@ -54,12 +54,12 @@ func.func @iterate(%input0: !wave.tensor<any of f32>, %input1: !wave.tensor<any 
   // don't need to exactly match those of iterate results as long as one of them
   // is underspecified.
   //
-  // CHECK: wave.iterate @I iter_args
-  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[@A] of f32>, %{{.*}}: !wave.tensor<[@B] of bf16>):
-  %iter_result:2 = wave.iterate @I iter_args(%input0, %input1) {
-  ^bb0(%in_arg0: !wave.tensor<[@A] of f32>, %in_arg1: !wave.tensor<[@B] of bf16>):
-    // CHECK: wave.yield %{{.*}}, %{{.*}} : !wave.tensor<[@A] of f32>, !wave.tensor<[@B] of bf16>
-    wave.yield %in_arg0, %in_arg1 : !wave.tensor<[@A] of f32>, !wave.tensor<[@B] of bf16>
+  // CHECK: wave.iterate <I> iter_args
+  // CHECK: ^{{.*}}(%{{.*}}: !wave.tensor<[<A>] of f32>, %{{.*}}: !wave.tensor<[<B>] of bf16>):
+  %iter_result:2 = wave.iterate <I> iter_args(%input0, %input1) {
+  ^bb0(%in_arg0: !wave.tensor<[<A>] of f32>, %in_arg1: !wave.tensor<[<B>] of bf16>):
+    // CHECK: wave.yield %{{.*}}, %{{.*}} : !wave.tensor<[<A>] of f32>, !wave.tensor<[<B>] of bf16>
+    wave.yield %in_arg0, %in_arg1 : !wave.tensor<[<A>] of f32>, !wave.tensor<[<B>] of bf16>
   } : (!wave.tensor<any of f32>, !wave.tensor<any of bf16>) -> (!wave.tensor<any of f32>, !wave.tensor<any of bf16>)
   return %iter_result#0, %iter_result#1 : !wave.tensor<any of f32>, !wave.tensor<any of bf16>
 }
@@ -67,8 +67,8 @@ func.func @iterate(%input0: !wave.tensor<any of f32>, %input1: !wave.tensor<any 
 // CHECK-LABEL: @register
 func.func @register() {
   %0 = arith.constant 0.0 : f32
-  // CHECK: wave.register %{{.*}} : !wave.tensor<[@Y, @Z] of f32>
-  %register = wave.register %0 : !wave.tensor<[@Y, @Z] of f32>
+  // CHECK: wave.register %{{.*}} : !wave.tensor<[<Y>, <Z>] of f32>
+  %register = wave.register %0 : !wave.tensor<[<Y>, <Z>] of f32>
   return
 }
 
@@ -78,10 +78,10 @@ func.func @register_with_symbols() {
   // CHECK: wave.register
   %register = wave.register %0
     index {
-      M : [THREAD_ID, BLOCK_SIZE] -> (THREAD_ID floordiv BLOCK_SIZE, 1, 1),
-      N : [THREAD_ID, BLOCK_SIZE] -> (THREAD_ID * BLOCK_SIZE + 42, 1, 1)
+      <M> : [<THREAD_ID>, <BLOCK_SIZE>] -> (THREAD_ID floordiv BLOCK_SIZE, 1, 1),
+      <N> : [<THREAD_ID>, <BLOCK_SIZE>] -> (THREAD_ID * BLOCK_SIZE + 42, 1, 1)
     }
-    : !wave.tensor<[@M, @N] of f32, <register>>
+    : !wave.tensor<[<M>, <N>] of f32, <register>>
   return
 }
 
@@ -91,11 +91,11 @@ func.func @register_with_symbols_complex_index() {
   // CHECK: wave.register
   %register = wave.register %0
     index {
-      B : [WG2, BLOCK_B] -> (WG2 * (BLOCK_B+BLOCK_B), BLOCK_B * (WG2+WG2), WG2 * BLOCK_B),
-      M : [_WG0, BLOCK_M, _T0] -> (_WG0 * BLOCK_M + BLOCK_M * ((_T0 floordiv 64) floordiv 2) + _T0 mod 32, 1, 1),
-      N : [_T1, BLOCK_N, _WG1, GPR_NUM, _T0] -> (_T1 * (BLOCK_N floordiv 2) + BLOCK_N * _WG1 + GPR_NUM mod 4 + ((GPR_NUM floordiv 4) mod 4) * 8 + ((_T0 mod 64) floordiv 32) * 4, 1, 1)
+      <B> : [<WG2>, <BLOCK_B>] -> (WG2 * (BLOCK_B+BLOCK_B), BLOCK_B * (WG2+WG2), WG2 * BLOCK_B),
+      <M> : [<WG0>, <BLOCK_M>, <T0>] -> (WG0 * BLOCK_M + BLOCK_M * ((T0 floordiv 64) floordiv 2) + T0 mod 32, 1, 1),
+      <N> : [<T1>, <BLOCK_N>, <WG1>, <GPR_NUM>, <T0>] -> (T1 * (BLOCK_N floordiv 2) + BLOCK_N * WG1 + GPR_NUM mod 4 + ((GPR_NUM floordiv 4) mod 4) * 8 + ((T0 mod 64) floordiv 32) * 4, 1, 1)
     }
-    : !wave.tensor<[@B, @N, @M] of f32, <register>>
+    : !wave.tensor<[<B>, <N>, <M>] of f32, <register>>
   return
 }
 
@@ -103,8 +103,8 @@ func.func @register_with_symbols_complex_index() {
 func.func @register_with_symbols_empty_symbol_list() {
   %0 = arith.constant 0.0 : f32
   // CHECK: wave.register
-  %register = wave.register %0 index {B : [] -> (0, 1, 1)}
-    : !wave.tensor<[@B] of f32, <register>>
+  %register = wave.register %0 index {<B> : [] -> (0, 1, 1)}
+    : !wave.tensor<[<B>] of f32, <register>>
   return
 }
 
@@ -114,40 +114,40 @@ func.func @register_with_hyperparameter() attributes {hyperparameters = #wave.hy
   %0 = arith.constant 0.0 : f32
   // CHECK: wave.register
   %register = wave.register %0
-    : !wave.tensor<[@A, @B] of f32, <register>>
+    : !wave.tensor<[<A>, <B>] of f32, <register>>
   return
 }
 
 // CHECK-LABEL: @allocate
-func.func @allocate() -> !wave.tensor<[@M, @N] of bf16, <shared>> {
+func.func @allocate() -> !wave.tensor<[<M>, <N>] of bf16, <shared>> {
   // CHECK: wave.allocate
-  %parent = wave.allocate { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>}
-    : !wave.tensor<[@M, @N] of bf16, <shared>>
+  %parent = wave.allocate { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> (BLOCK_M, BLOCK_K + 4)>}
+    : !wave.tensor<[<M>, <N>] of bf16, <shared>>
 
-  %buf = wave.allocate in %parent : !wave.tensor<[@M, @N] of bf16, <shared>>
-    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 64}
-    : !wave.tensor<[@M, @N] of bf16, <shared>>
+  %buf = wave.allocate in %parent : !wave.tensor<[<M>, <N>] of bf16, <shared>>
+    { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> (BLOCK_M, BLOCK_K + 4)>, offset = 64}
+    : !wave.tensor<[<M>, <N>] of bf16, <shared>>
 
-  return %buf : !wave.tensor<[@M, @N] of bf16, <shared>>
+  return %buf : !wave.tensor<[<M>, <N>] of bf16, <shared>>
 }
 
 // CHECK-LABEL: @index_magic_symbols
-func.func @index_magic_symbols(%mem: !wave.tensor<[@M] of f16, <global>>)
+func.func @index_magic_symbols(%mem: !wave.tensor<[<M>] of f16, <global>>)
 attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 32, BLOCK_N = 32, M = 128, N = 256}>}  {
   // CHECK: wave.read
   // CHECK: index
-  // CHECK: _WG0
-  // CHECK: _T0
+  // CHECK: WG0
+  // CHECK: T0
   %0 = wave.read %mem index {
-      M : [BLOCK_M, _WG0, _T0] -> (BLOCK_M * _WG0 + (BLOCK_M floordiv 2) * (_T0 floordiv 64) + _T0 mod 64, 1, 64),
-      N : [_T1, _WG1, BLOCK_N] -> (_WG1 * BLOCK_N + (BLOCK_N floordiv 2) * _T1, BLOCK_N ceildiv 2, 1)}
-    : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+      <M> : [<BLOCK_M>, <WG0>, <T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
+      <N> : [<T1>, <WG1>, <BLOCK_N>] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}
+    : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
   return
 }
 
 // CHECK-LABEL: @write_with_bounds
-func.func @write_with_bounds(%memo: !wave.tensor<[@M] of f32>, %val: !wave.tensor<[@M] of f32, <register>>) {
+func.func @write_with_bounds(%memo: !wave.tensor<[<M>] of f32>, %val: !wave.tensor<[<M>] of f32, <register>>) {
   // CHECK:       wave.read_write_bounds
-  wave.write %val, %memo { bounds = #wave.read_write_bounds<{ M = #wave.expr<[BLOCK_M] -> (BLOCK_M * 64)>}> } : !wave.tensor<[@M] of f32, <register>>, !wave.tensor<[@M] of f32>
+  wave.write %val, %memo { bounds = #wave.read_write_bounds<{ M = #wave.expr<[<BLOCK_M>] -> (BLOCK_M * 64)>}> } : !wave.tensor<[<M>] of f32, <register>>, !wave.tensor<[<M>] of f32>
   return
 }

--- a/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -4,7 +4,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
   func.func @register_alone() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 10, Z = 1}>} {
     %cst = arith.constant 0.0 : f32
     // expected-error @below {{couldn't identify elements per thread for result #0}}
-    wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+    wave.register %cst : !wave.tensor<[<Y>, <Z>] of f32, <register>>
     return
   }
 }
@@ -15,8 +15,8 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
   func.func @register_add() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 10, Z = 1}>} {
     %cst = arith.constant 0.0 : f32
     // expected-error @below {{couldn't identify elements per thread for result #0}}
-    %reg = wave.register %cst { elements_per_thread = 4 } : !wave.tensor<[@Y, @Z] of f32, <register>>
-    wave.add %reg, %reg : (!wave.tensor<[@Y, @Z] of f32, <register>>, !wave.tensor<[@Y, @Z] of f32, <register>>) -> !wave.tensor<[@Y, @Z] of f32, <register>>
+    %reg = wave.register %cst { elements_per_thread = 4 } : !wave.tensor<[<Y>, <Z>] of f32, <register>>
+    wave.add %reg, %reg : (!wave.tensor<[<Y>, <Z>] of f32, <register>>, !wave.tensor<[<Y>, <Z>] of f32, <register>>) -> !wave.tensor<[<Y>, <Z>] of f32, <register>>
     return
   }
 }
@@ -26,13 +26,13 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // CHECK: #wave.normal_form<memory_only_types>
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // CHECK-LABEL: @propagate_register_write
-func.func @propagate_register_write(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+func.func @propagate_register_write(%mem: !wave.tensor<[<M>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
   %cst = arith.constant 0.0 : f16
   // CHECK: wave.register {{.*}} : vector<8xf16>
-  %reg = wave.register %cst : !wave.tensor<[@M] of f16, <register>>
-  // CHECK: wave.write {{.*}} : vector<8xf16>, !wave.tensor<[@M] of f16, <global>>
+  %reg = wave.register %cst : !wave.tensor<[<M>] of f16, <register>>
+  // CHECK: wave.write {{.*}} : vector<8xf16>, !wave.tensor<[<M>] of f16, <global>>
   wave.write %reg, %mem { elements_per_thread = 8 }
-     : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+     : !wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <global>>
   return
 }
 }
@@ -42,23 +42,23 @@ func.func @propagate_register_write(%mem: !wave.tensor<[@M] of f16, <global>>) a
 // CHECK: #wave.normal_form<memory_only_types>
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // CHECK-LABEL: @propagate_backward_from_write
-func.func @propagate_backward_from_write(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+func.func @propagate_backward_from_write(%mem: !wave.tensor<[<M>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
   %cst = arith.constant 0.0 : f16
   // CHECK: wave.register {{.*}} : vector<8xf16>
-  %reg = wave.register %cst : !wave.tensor<[@M] of f16, <register>>
+  %reg = wave.register %cst : !wave.tensor<[<M>] of f16, <register>>
   %cst2 = arith.constant 42.0 : f16
   // CHECK: wave.register {{.*}} : vector<8xf16>
-  %reg2 = wave.register %cst2 : !wave.tensor<[@M] of f16, <register>>
+  %reg2 = wave.register %cst2 : !wave.tensor<[<M>] of f16, <register>>
   // CHECK: wave.add {{.*}} : (vector<8xf16>, vector<8xf16>) -> vector<8xf16>
-  %sum = wave.add %reg, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  %sum = wave.add %reg, %reg2 : (!wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
   // CHECK: wave.mul {{.*}} : (vector<8xf16>, vector<8xf16>) -> vector<8xf16>
-  %mul = wave.mul %sum, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  %mul = wave.mul %sum, %reg2 : (!wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
   // CHECK: wave.exp2 {{.*}} : (vector<8xf16>) -> vector<8xf16>
-  %exp = wave.exp2 %mul : (!wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  %exp = wave.exp2 %mul : (!wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
 
-  // CHECK: wave.write {{.*}} : vector<8xf16>, !wave.tensor<[@M] of f16, <global>>
+  // CHECK: wave.write {{.*}} : vector<8xf16>, !wave.tensor<[<M>] of f16, <global>>
   wave.write %exp, %mem { elements_per_thread = 8 }
-     : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+     : !wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <global>>
   return
 }
 }
@@ -68,18 +68,18 @@ func.func @propagate_backward_from_write(%mem: !wave.tensor<[@M] of f16, <global
 // CHECK: #wave.normal_form<memory_only_types>
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // CHECK-LABEL: @propagate_forward_from_read
-func.func @propagate_forward_from_read(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
-  // CHECK: wave.read {{.*}} : (!wave.tensor<[@M] of f16, <global>>) -> vector<4xf16>
-  %reg = wave.read %mem { elements_per_thread = 4 } : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+func.func @propagate_forward_from_read(%mem: !wave.tensor<[<M>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  // CHECK: wave.read {{.*}} : (!wave.tensor<[<M>] of f16, <global>>) -> vector<4xf16>
+  %reg = wave.read %mem { elements_per_thread = 4 } : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
   %cst2 = arith.constant 42.0 : f16
   // CHECK: wave.register {{.*}} : vector<4xf16>
-  %reg2 = wave.register %cst2 : !wave.tensor<[@M] of f16, <register>>
+  %reg2 = wave.register %cst2 : !wave.tensor<[<M>] of f16, <register>>
   // CHECK: wave.add {{.*}} : (vector<4xf16>, vector<4xf16>) -> vector<4xf16>
-  %sum = wave.add %reg, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  %sum = wave.add %reg, %reg2 : (!wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
   // CHECK: wave.mul {{.*}} : (vector<4xf16>, vector<4xf16>) -> vector<4xf16>
-  %mul = wave.mul %sum, %reg2 : (!wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  %mul = wave.mul %sum, %reg2 : (!wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
   // CHECK: wave.exp2 {{.*}} : (vector<4xf16>) -> vector<4xf16>
-  %exp = wave.exp2 %mul : (!wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+  %exp = wave.exp2 %mul : (!wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
 
   return
 }
@@ -88,9 +88,9 @@ func.func @propagate_forward_from_read(%mem: !wave.tensor<[@M] of f16, <global>>
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
-func.func @missing_elements_per_thread(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+func.func @missing_elements_per_thread(%mem: !wave.tensor<[<M>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
   // expected-error @below {{couldn't identify elements per thread for result #0}}
-  %reg = wave.read %mem : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+  %reg = wave.read %mem : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
   return
 }
 }
@@ -98,10 +98,10 @@ func.func @missing_elements_per_thread(%mem: !wave.tensor<[@M] of f16, <global>>
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
-func.func @read_write_conflict(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
-  %reg = wave.read %mem {elements_per_thread = 4} : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+func.func @read_write_conflict(%mem: !wave.tensor<[<M>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  %reg = wave.read %mem {elements_per_thread = 4} : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
   // expected-error @below {{failed to propagate elements per thread backward: mismatch between elements_per_thread attribute (8) and operand #0 (4)}}
-  wave.write %reg, %mem {elements_per_thread = 8} : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  wave.write %reg, %mem {elements_per_thread = 8} : !wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <global>>
   return
 }
 }
@@ -109,11 +109,11 @@ func.func @read_write_conflict(%mem: !wave.tensor<[@M] of f16, <global>>) attrib
 // -----
 
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
-func.func @read_write_conflict_indirect(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
-  %reg = wave.read %mem {elements_per_thread = 4} : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
-  %val = wave.exp2 %reg : (!wave.tensor<[@M] of f16, <register>>) -> !wave.tensor<[@M] of f16, <register>>
+func.func @read_write_conflict_indirect(%mem: !wave.tensor<[<M>] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
+  %reg = wave.read %mem {elements_per_thread = 4} : (!wave.tensor<[<M>] of f16, <global>>) -> !wave.tensor<[<M>] of f16, <register>>
+  %val = wave.exp2 %reg : (!wave.tensor<[<M>] of f16, <register>>) -> !wave.tensor<[<M>] of f16, <register>>
   // expected-error @below {{failed to propagate elements per thread backward: mismatch between elements_per_thread attribute (8) and operand #0 (4)}}
-  wave.write %reg, %mem {elements_per_thread = 8} : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  wave.write %reg, %mem {elements_per_thread = 8} : !wave.tensor<[<M>] of f16, <register>>, !wave.tensor<[<M>] of f16, <global>>
   return
 }
 }
@@ -125,12 +125,12 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 func.func @alloc_is_harmless() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
   // CHECK: wave.allocate
   %parent = wave.allocate { distributed_shape = #wave.expr<[] -> (256)> }
-    : !wave.tensor<[@M,@N,@K] of i8, <shared>>
+    : !wave.tensor<[<M>,<N>,<K>] of i8, <shared>>
 
   // CHECK: wave.allocate
-  %buf = wave.allocate in %parent : !wave.tensor<[@M,@N,@K] of i8, <shared>>
-    { distributed_shape = #wave.expr<[BLOCK_M, BLOCK_K] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
-    : !wave.tensor<[@M, @K] of bf16, <shared>>
+  %buf = wave.allocate in %parent : !wave.tensor<[<M>,<N>,<K>] of i8, <shared>>
+    { distributed_shape = #wave.expr<[<BLOCK_M>, <BLOCK_K>] -> (BLOCK_M, BLOCK_K + 4)>, offset = 128}
+    : !wave.tensor<[<M>, <K>] of bf16, <shared>>
   return
   }
 }
@@ -140,9 +140,9 @@ func.func @alloc_is_harmless() attributes {wave.hyperparameters = #wave.hyperpar
 module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 func.func @unsupported_op() attributes {wave.hyperparameters = #wave.hyperparameters<{Y = 100, Z = 200}>}  {
   %cst = arith.constant 42.0 : f32
-  %reg = wave.register %cst : !wave.tensor<[@Y, @Z] of f32, <register>>
+  %reg = wave.register %cst : !wave.tensor<[<Y>, <Z>] of f32, <register>>
   // expected-error @below {{cannot propagate elements per thread information across an operation not implementing the corresponding interface}}
-  "foo.bar"(%reg) : (!wave.tensor<[@Y, @Z] of f32, <register>>) -> !wave.tensor<[@Y, @Z] of f32, <register>>
+  "foo.bar"(%reg) : (!wave.tensor<[<Y>, <Z>] of f32, <register>>) -> !wave.tensor<[<Y>, <Z>] of f32, <register>>
   return
 }
 }

--- a/test/Transforms/wave_gemm.mlir
+++ b/test/Transforms/wave_gemm.mlir
@@ -1,25 +1,25 @@
 // RUN: water-opt %s
 
-func.func @gemm(%a: !wave.tensor<[@M, @K] of bf16, <shared>>,
-               %b: !wave.tensor<[@N, @K] of bf16, <shared>>,
-               %c: !wave.tensor<[@M, @N] of f32, <global>>) {
+func.func @gemm(%a: !wave.tensor<[<M>, <K>] of bf16, <shared>>,
+               %b: !wave.tensor<[<N>, <K>] of bf16, <shared>>,
+               %c: !wave.tensor<[<M>, <N>] of f32, <global>>) {
 
   %0 = arith.constant 0.0 : f32
-  %c_reg = wave.register %0 : !wave.tensor<[@M, @N] of f32>
+  %c_reg = wave.register %0 : !wave.tensor<[<M>, <N>] of f32>
 
-  %mma_result = wave.iterate @K iter_args(%c_reg) {
-  ^bb0(%acc: !wave.tensor<[@M, @N] of f32>):
+  %mma_result = wave.iterate <K> iter_args(%c_reg) {
+  ^bb0(%acc: !wave.tensor<[<M>, <N>] of f32>):
 
-    %a_reg = wave.read %a : (!wave.tensor<[@M, @K] of bf16, <shared>>) -> !wave.tensor<[@M, @K] of bf16>
-    %b_reg = wave.read %b : (!wave.tensor<[@N, @K] of bf16, <shared>>) -> !wave.tensor<[@N, @K] of bf16>
+    %a_reg = wave.read %a : (!wave.tensor<[<M>, <K>] of bf16, <shared>>) -> !wave.tensor<[<M>, <K>] of bf16>
+    %b_reg = wave.read %b : (!wave.tensor<[<N>, <K>] of bf16, <shared>>) -> !wave.tensor<[<N>, <K>] of bf16>
 
     %inner_acc = wave.mma %a_reg, %b_reg, %acc {kind = #wave.mma_kind<f32_32x32x16_bf16>} :
-      (!wave.tensor<[@M, @K] of bf16>, !wave.tensor<[@N, @K] of bf16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
+      (!wave.tensor<[<M>, <K>] of bf16>, !wave.tensor<[<N>, <K>] of bf16>, !wave.tensor<[<M>, <N>] of f32>) -> !wave.tensor<[<M>, <N>] of f32>
 
-    wave.yield %inner_acc : !wave.tensor<[@M, @N] of f32>
-  } : (!wave.tensor<[@M, @N] of f32>)-> (!wave.tensor<[@M, @N] of f32>)
+    wave.yield %inner_acc : !wave.tensor<[<M>, <N>] of f32>
+  } : (!wave.tensor<[<M>, <N>] of f32>)-> (!wave.tensor<[<M>, <N>] of f32>)
 
-  wave.write %mma_result, %c : !wave.tensor<[@M, @N] of f32> , !wave.tensor<[@M, @N] of f32, <global>>
+  wave.write %mma_result, %c : !wave.tensor<[<M>, <N>] of f32> , !wave.tensor<[<M>, <N>] of f32, <global>>
 
   return
 }

--- a/test/lib/Transforms/TestWaveDialectConstructors.cpp
+++ b/test/lib/Transforms/TestWaveDialectConstructors.cpp
@@ -32,13 +32,14 @@ static llvm::LogicalResult testCreateTensor(mlir::Operation *op) {
 
   llvm::SmallVector<wave::WaveSymbolAttr> shapeComponents;
   for (mlir::Attribute a : shapeAttr.getValue()) {
-    if (auto symbol = llvm::dyn_cast<mlir::FlatSymbolRefAttr>(a)) {
-      shapeComponents.emplace_back(
-          wave::WaveSymbolAttr::get(op->getContext(), symbol.getValue()));
+    if (auto symbol = llvm::dyn_cast<wave::WaveSymbolAttr>(a)) {
+      shapeComponents.emplace_back(wave::WaveSymbolAttr::get(
+          op->getContext(), wave::WaveIndexSymbol::NON_INDEX,
+          symbol.getName()));
       continue;
     }
     return op->emitOpError() << "expected elements of the \"" << kShape
-                             << "\" attribute to be flat symbol references";
+                             << "\" attribute to be wave symbol attributes";
   }
 
   mlir::Type elementType = mlir::IndexType::get(op->getContext());


### PR DESCRIPTION
This PR makes sure:
- that all attributes using `WaveSymbols` use the same parser and printer (making sure we can re-parse our ir)
- we have a single source of truth to distinguish between user WaveSymbols and index WaveSymbols.

Python bindings are still wip for now (still need to replace SymbolName strings with WaveSymbolAttr attributes for some constructors).