### PR TITLE
Replace deprecated op vector.splat with vector.broadcast

### DIFF
--- a/lib/Transforms/AccessCheckers.cpp
+++ b/lib/Transforms/AccessCheckers.cpp
@@ -249,7 +249,7 @@ static Value createDummyValue(OpBuilder &builder, Location loc, Type type) {
     Value element = createDummyValue(builder, loc, vecType.getElementType());
     if (!element)
       return nullptr;
-    return builder.create<vector::SplatOp>(loc, element, vecType);
+    return builder.create<vector::BroadcastOp>(loc, vecType, element);
   }
   return nullptr;
 }

--- a/lib/Transforms/SLPVectorizer.cpp
+++ b/lib/Transforms/SLPVectorizer.cpp
@@ -1129,7 +1129,7 @@ SLPGraph::vectorize(IRRewriter &rewriter,
             assert(vecType.getRank() <= 1);
             if (vecType.getRank() == 0) {
               elem = rewriter.create<vector::ExtractOp>(loc, newResult, offset);
-              elem = rewriter.create<vector::SplatOp>(loc, vecType, elem);
+              elem = rewriter.create<vector::BroadcastOp>(loc, vecType, elem);
             } else {
               elem = rewriter.create<vector::ExtractStridedSliceOp>(
                   loc, newResult, offset, vecType.getNumElements(), 1);

--- a/test/Transforms/slp-vectorize.mlir
+++ b/test/Transforms/slp-vectorize.mlir
@@ -845,9 +845,9 @@ func.func @read_read_add_add_vec0d(%arg0: memref<8xi32>, %arg1: memref<8xi32>) -
   // CHECK: %[[V1:.*]] = vector.load %[[ARG1]][%[[C0]]] : memref<8xi32>, vector<2xi32>
   // CHECK: %[[V2:.*]] = arith.addi %[[V0]], %[[V1]] : vector<2xi32>
   // CHECK: %[[V3:.*]] = vector.extract %[[V2]][0] : i32 from vector<2xi32>
-  // CHECK: %[[V4:.*]] = vector.splat %[[V3]] : vector<i32>
+  // CHECK: %[[V4:.*]] = vector.broadcast %[[V3]] : i32 to vector<i32>
   // CHECK: %[[V5:.*]] = vector.extract %[[V2]][1] : i32 from vector<2xi32>
-  // CHECK: %[[V6:.*]] = vector.splat %[[V5]] : vector<i32>
+  // CHECK: %[[V6:.*]] = vector.broadcast %[[V5]] : i32 to vector<i32>
   // CHECK: return %[[V4]], %[[V6]] : vector<i32>, vector<i32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index


### PR DESCRIPTION
Signed-off-by: Tim Gymnich <tim.gymnich@amd.com>
